### PR TITLE
Reorganize knowledge base UI - add Cloud button to Add Knowledge dialog

### DIFF
--- a/frontend/src/components/agents/config/configuration-tab.tsx
+++ b/frontend/src/components/agents/config/configuration-tab.tsx
@@ -4,7 +4,6 @@ import { ExpandableMarkdownEditor } from '@/components/ui/expandable-markdown-ed
 import { AgentToolsConfiguration } from '../agent-tools-configuration';
 import { AgentMCPConfiguration } from '../agent-mcp-configuration';
 import { AgentKnowledgeBaseManager } from '../knowledge-base/agent-knowledge-base-manager';
-import { LlamaCloudKnowledgeBaseManager } from '../llamacloud-knowledge-base/llamacloud-kb-manager';
 import { AgentPlaybooksConfiguration } from '../playbooks/agent-playbooks-configuration';
 import { AgentTriggersConfiguration } from '../triggers/agent-triggers-configuration';
 import { AgentModelSelector } from './model-selector';
@@ -290,42 +289,6 @@ export function ConfigurationTab({
                   </div>
                 </div>
               )}
-            </div>
-            
-            <div className="group overflow-hidden rounded-2xl border border-border bg-card transition-all duration-300 hover:border-primary/10" data-tour="knowledge-section">
-              <button
-                className="w-full p-4 text-left group-hover:bg-muted/30 transition-all duration-300"
-                onClick={() => setOpenAccordion(openAccordion === 'llamacloud-knowledge' ? '' : 'llamacloud-knowledge')}
-                disabled={isLoading}
-              >
-                <div className="flex items-center gap-4 w-full">
-                  <div className="relative flex-shrink-0">
-                    <div className="bg-blue-100 dark:bg-blue-900/20 rounded-xl h-10 w-10 flex items-center justify-center transition-all duration-300 group-hover:scale-105">
-                      <BookOpen className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                    </div>
-                  </div>
-                  <div className="text-left flex-1 min-w-0">
-                    <h4 className="text-sm font-semibold text-foreground mb-1 group-hover:text-primary transition-colors duration-300">Knowledge Base - Cloud</h4>
-                    <p className="text-xs text-muted-foreground group-hover:text-foreground/70 transition-colors duration-300">Connect to existing Cloud Knowledge Base for dynamic search</p>
-                  </div>
-                  <ChevronDown className={`h-4 w-4 flex-shrink-0 transition-transform duration-300 ease-out ${openAccordion === 'llamacloud-knowledge' ? 'rotate-180' : ''}`} />
-                </div>
-              </button>
-              <div
-                className={`overflow-hidden transition-all duration-300 ease-out ${openAccordion === 'llamacloud-knowledge'
-                  ? 'max-h-[600px] opacity-100'
-                  : 'max-h-0 opacity-0'
-                  }`}
-              >
-                <div className="px-6 pb-6 pt-2">
-                  <div className="pt-4">
-                    <LlamaCloudKnowledgeBaseManager
-                      agentId={agentId}
-                      agentName={displayData.name || 'Agent'}
-                    />
-                  </div>
-                </div>
-              </div>
             </div>
             
             <div className="group overflow-hidden rounded-2xl border border-border bg-card transition-all duration-300 hover:border-primary/10">

--- a/frontend/src/components/agents/knowledge-base/agent-knowledge-base-manager.tsx
+++ b/frontend/src/components/agents/knowledge-base/agent-knowledge-base-manager.tsx
@@ -60,6 +60,7 @@ import { cn, truncateString } from '@/lib/utils';
 import { CreateKnowledgeBaseEntryRequest, KnowledgeBaseEntry, UpdateKnowledgeBaseEntryRequest, ProcessingJob } from '@/hooks/react-query/knowledge-base/types';
 import { toast } from 'sonner';
 import JSZip from 'jszip';
+import { LlamaCloudKnowledgeBaseManager } from '../llamacloud-knowledge-base/llamacloud-kb-manager';
 
 import { 
   Code2 as SiJavascript, 
@@ -282,7 +283,7 @@ export const AgentKnowledgeBaseManager = ({ agentId, agentName }: AgentKnowledge
   const [deleteEntryId, setDeleteEntryId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [addDialogOpen, setAddDialogOpen] = useState(false);
-  const [addDialogMode, setAddDialogMode] = useState<'selection' | 'manual' | 'files'>('selection');
+  const [addDialogMode, setAddDialogMode] = useState<'selection' | 'manual' | 'files' | 'cloud'>('selection');
   const [dragActive, setDragActive] = useState(false);
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -921,6 +922,21 @@ export const AgentKnowledgeBaseManager = ({ agentId, agentName }: AgentKnowledge
                       </p>
                     </div>
                   </button>
+                  
+                  <button
+                    className="flex items-center gap-4 p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors text-left"
+                    onClick={() => setAddDialogMode('cloud')}
+                  >
+                    <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/20 border">
+                      <Globe className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    </div>
+                    <div className="flex-1">
+                      <h3 className="text-sm font-semibold mb-1">Cloud</h3>
+                      <p className="text-xs text-muted-foreground">
+                        Connect to existing Cloud Knowledge Base for dynamic search
+                      </p>
+                    </div>
+                  </button>
                 </div>
               </div>
             )}
@@ -1170,6 +1186,29 @@ export const AgentKnowledgeBaseManager = ({ agentId, agentName }: AgentKnowledge
                     </div>
                   )}
                 </div>
+              </div>
+            )}
+
+            {addDialogMode === 'cloud' && (
+              <div className="p-6">
+                <div className="mb-6">
+                  <div className="flex items-center gap-3 mb-2">
+                    <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/20 border">
+                      <Globe className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-semibold">Cloud Knowledge Base</h3>
+                      <p className="text-sm text-muted-foreground">
+                        Connect to existing Cloud Knowledge Base for dynamic search
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                
+                <LlamaCloudKnowledgeBaseManager 
+                  agentId={agentId} 
+                  agentName={agentName}
+                />
               </div>
             )}
           </div>


### PR DESCRIPTION
- Add Cloud button as third option in 'Add Knowledge to pod' dialog
- Remove separate 'Knowledge Base - Cloud' section from configuration tab
- Cloud button links to LlamaCloudKnowledgeBaseManager for dynamic search
- Now all knowledge options (Write, Upload, Cloud) are in one unified dialog
- Clean up unused imports in configuration tab