### PR TITLE
Increase anthropic api call ttl to one hour

### DIFF
--- a/backend/core/utils/cache.py
+++ b/backend/core/utils/cache.py
@@ -12,7 +12,7 @@ class _cache:
             return json.loads(result)
         return None
 
-    async def set(self, key: str, value: Any, ttl: int = 15 * 60):
+    async def set(self, key: str, value: Any, ttl: int = 60 * 60):
         redis = await get_client()
         key = f"cache:{key}"
         await redis.set(key, json.dumps(value), ex=ttl)


### PR DESCRIPTION
Increase the default application cache TTL from 15 minutes to one hour to improve performance for cached data, including Anthropic-related calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea03a9dd-f6ef-4fb7-8afe-4e71841b87a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea03a9dd-f6ef-4fb7-8afe-4e71841b87a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

