### PR TITLE
Configure background worker and handle errors

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -31,6 +31,7 @@ from core.services import email_api
 from core.services import memory_api
 from core.triggers import api as triggers_api
 from core.services import api_keys_api
+from core.services import enterprise_billing_api
 
 
 if sys.platform == "win32":


### PR DESCRIPTION
Add missing import for `enterprise_billing_api` to fix `NameError` during Gunicorn startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-4047415f-bfb9-489e-aa95-b57a9a72445a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4047415f-bfb9-489e-aa95-b57a9a72445a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

