### PR TITLE
Tool Usage Credit Deduction

### DIFF
--- a/backend/core/billing/tool_billing.py
+++ b/backend/core/billing/tool_billing.py
@@ -351,6 +351,20 @@ class ToolBillingService:
         }
 
     # ================================================================== #
+    #  Cost lookup (for agent awareness)
+    # ================================================================== #
+
+    async def get_tool_costs(self, tool_names: List[str]) -> Dict[str, float]:
+        """
+        Look up per-invocation costs for *tool_names*. Used to inject cost
+        into tool descriptions so agents see them when choosing tools.
+        """
+        if not tool_names:
+            return {}
+        costs = await self._get_tool_costs_batch(tool_names)
+        return {name: float(c) for name, c in costs.items() if c > 0}
+
+    # ================================================================== #
     #  Helpers
     # ================================================================== #
 

--- a/backend/core/billing/tool_billing.py
+++ b/backend/core/billing/tool_billing.py
@@ -1,0 +1,416 @@
+"""
+Tool Billing Service
+
+Encapsulates all tool-level credit operations:
+  - Pre-flight check  (can the user afford to run this tool?)
+  - Post-execution deduction (charge the user after a successful tool call)
+
+Both Enterprise and SaaS paths are handled here so callers never need
+to know which billing mode is active.
+"""
+
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+from core.billing.credits.manager import credit_manager
+from core.services.supabase import DBConnection
+from core.utils.config import config, EnvMode
+from core.utils.logger import logger
+from core.billing.shared.cache_utils import invalidate_account_state_cache
+
+
+class ToolBillingService:
+    """
+    Centralised service for per-tool credit checks and deductions.
+
+    Callers should use the public methods:
+
+        can_use_tool        -- lightweight read-only check for a single tool
+        can_use_tools_batch -- lightweight read-only check for multiple tools
+        deduct_tool         -- atomic deduction (call after a successful tool execution)
+    """
+
+    # ------------------------------------------------------------------ #
+    #  Pre-flight check
+    # ------------------------------------------------------------------ #
+
+    async def can_use_tool(
+        self,
+        account_id: str,
+        tool_name: str,
+    ) -> Dict:
+        """
+        Check whether *account_id* can afford to execute *tool_name*.
+
+        Returns
+        -------
+        dict
+            Always contains ``can_use: bool``.
+            On success also contains ``required_cost``, ``current_balance``,
+            and ``user_remaining``.
+        """
+        if config.ENV_MODE == EnvMode.LOCAL:
+            return {"can_use": True, "required_cost": 0, "reason": "local_mode"}
+
+        try:
+            if config.ENTERPRISE_MODE:
+                return await self._enterprise_can_use_tool(account_id, tool_name)
+            else:
+                return await self._saas_can_use_tool(account_id, tool_name)
+        except Exception as e:
+            logger.error(f"[TOOL_BILLING] Error in can_use_tool for {account_id}/{tool_name}: {e}")
+            # Fail-open: don't block tool execution on billing errors
+            return {"can_use": True, "required_cost": 0, "reason": "check_error", "error": str(e)}
+
+    # ------------------------------------------------------------------ #
+    #  Batch pre-flight check
+    # ------------------------------------------------------------------ #
+
+    async def can_use_tools_batch(
+        self,
+        account_id: str,
+        tool_names: List[str],
+    ) -> Dict:
+        """
+        Check whether *account_id* can afford to execute **all** tools in
+        *tool_names* at once.
+
+        For a single tool this delegates to :meth:`can_use_tool`.
+
+        Returns
+        -------
+        dict
+            Always contains ``can_use: bool`` and ``total_cost: float``.
+            Enterprise responses additionally include ``current_balance``
+            and ``user_remaining``.
+        """
+        if config.ENV_MODE == EnvMode.LOCAL:
+            return {"can_use": True, "total_cost": 0, "reason": "local_mode"}
+
+        if not tool_names:
+            return {"can_use": True, "total_cost": 0, "reason": "no_tools"}
+
+        # Single-tool fast path – reuse the existing method
+        if len(tool_names) == 1:
+            result = await self.can_use_tool(account_id, tool_names[0])
+            # Normalise keys so callers always see total_cost
+            result.setdefault("total_cost", result.get("required_cost", 0))
+            return result
+
+        try:
+            if config.ENTERPRISE_MODE:
+                return await self._enterprise_can_use_tools_batch(account_id, tool_names)
+            else:
+                return await self._saas_can_use_tools_batch(account_id, tool_names)
+        except Exception as e:
+            logger.error(
+                f"[TOOL_BILLING] Error in can_use_tools_batch for "
+                f"{account_id}/{tool_names}: {e}"
+            )
+            # Fail-open: don't block tool execution on billing errors
+            return {
+                "can_use": True,
+                "total_cost": 0,
+                "reason": "check_error",
+                "error": str(e),
+            }
+
+    # ------------------------------------------------------------------ #
+    #  Post-execution deduction
+    # ------------------------------------------------------------------ #
+
+    async def deduct_tool(
+        self,
+        account_id: str,
+        tool_name: str,
+        thread_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Dict:
+        """
+        Deduct credits for a successful execution of *tool_name*.
+
+        Returns
+        -------
+        dict
+            Always contains ``success: bool`` and ``cost: float``.
+            Enterprise responses additionally include ``new_balance``
+            and ``user_remaining``.
+        """
+        if config.ENV_MODE == EnvMode.LOCAL:
+            return {"success": True, "cost": 0, "reason": "local_mode"}
+
+        try:
+            if config.ENTERPRISE_MODE:
+                return await self._enterprise_deduct_tool(
+                    account_id, tool_name, thread_id, message_id
+                )
+            else:
+                return await self._saas_deduct_tool(
+                    account_id, tool_name, thread_id, message_id
+                )
+        except Exception as e:
+            logger.error(f"[TOOL_BILLING] Error in deduct_tool for {account_id}/{tool_name}: {e}")
+            return {"success": False, "cost": 0, "error": str(e)}
+
+    # ================================================================== #
+    #  Enterprise implementation
+    # ================================================================== #
+
+    async def _enterprise_can_use_tool(self, account_id: str, tool_name: str) -> Dict:
+        db = DBConnection()
+        client = await db.client
+
+        result = await client.rpc(
+            "enterprise_can_use_tool",
+            {"p_account_id": account_id, "p_tool_name": tool_name},
+        ).execute()
+
+        if not result.data:
+            logger.error(f"[TOOL_BILLING] Empty response from enterprise_can_use_tool for {account_id}/{tool_name}")
+            return {"can_use": True, "required_cost": 0, "reason": "empty_response"}
+
+        # The RPC returns a single-row table
+        row = result.data[0] if isinstance(result.data, list) else result.data
+        return {
+            "can_use": bool(row.get("can_use", True)),
+            "required_cost": float(row.get("required_cost", 0)),
+            "current_balance": float(row.get("current_balance", 0)),
+            "user_remaining": float(row.get("user_remaining", 0)),
+        }
+
+    async def _enterprise_can_use_tools_batch(
+        self, account_id: str, tool_names: List[str]
+    ) -> Dict:
+        db = DBConnection()
+        client = await db.client
+
+        result = await client.rpc(
+            "enterprise_can_use_tools_batch",
+            {"p_account_id": account_id, "p_tool_names": tool_names},
+        ).execute()
+
+        if not result.data:
+            logger.error(
+                f"[TOOL_BILLING] Empty response from enterprise_can_use_tools_batch "
+                f"for {account_id}/{tool_names}"
+            )
+            return {"can_use": True, "total_cost": 0, "reason": "empty_response"}
+
+        row = result.data[0] if isinstance(result.data, list) else result.data
+        return {
+            "can_use": bool(row.get("can_use", True)),
+            "total_cost": float(row.get("total_cost", 0)),
+            "current_balance": float(row.get("current_balance", 0)),
+            "user_remaining": float(row.get("user_remaining", 0)),
+        }
+
+    async def _enterprise_deduct_tool(
+        self,
+        account_id: str,
+        tool_name: str,
+        thread_id: Optional[str],
+        message_id: Optional[str],
+    ) -> Dict:
+        db = DBConnection()
+        client = await db.client
+
+        result = await client.rpc(
+            "enterprise_use_tool_credits",
+            {
+                "p_account_id": account_id,
+                "p_tool_name": tool_name,
+                "p_thread_id": thread_id,
+                "p_message_id": message_id,
+            },
+        ).execute()
+
+        if not result.data:
+            logger.error(f"[TOOL_BILLING] Empty response from enterprise_use_tool_credits for {account_id}/{tool_name}")
+            return {"success": False, "cost": 0, "error": "empty_response"}
+
+        row = result.data[0] if isinstance(result.data, list) else result.data
+        success = bool(row.get("success", False))
+        cost = float(row.get("cost_charged", 0))
+
+        if success:
+            logger.info(
+                f"[TOOL_BILLING] Enterprise deducted ${cost:.4f} for tool '{tool_name}' "
+                f"(user={account_id}, balance=${row.get('new_balance', 0):.2f})"
+            )
+        else:
+            logger.warning(
+                f"[TOOL_BILLING] Enterprise deduction failed for tool '{tool_name}' "
+                f"(user={account_id})"
+            )
+
+        return {
+            "success": success,
+            "cost": cost,
+            "new_balance": float(row.get("new_balance", 0)),
+            "user_remaining": float(row.get("user_remaining", 0)),
+        }
+
+    # ================================================================== #
+    #  SaaS implementation
+    # ================================================================== #
+
+    async def _saas_can_use_tool(self, account_id: str, tool_name: str) -> Dict:
+        """
+        SaaS pre-check: look up the tool cost from the ``tool_costs`` table
+        and compare against the user's credit balance.
+        """
+        cost = await self._get_tool_cost(tool_name)
+
+        # Free tools always pass
+        if cost <= 0:
+            return {"can_use": True, "required_cost": 0}
+
+        balance_info = await credit_manager.get_balance(account_id)
+        if isinstance(balance_info, dict):
+            balance = Decimal(str(balance_info.get("total", 0)))
+        else:
+            balance = Decimal(str(balance_info or 0))
+
+        can_use = balance >= cost
+        return {
+            "can_use": can_use,
+            "required_cost": float(cost),
+            "current_balance": float(balance),
+        }
+
+    async def _saas_deduct_tool(
+        self,
+        account_id: str,
+        tool_name: str,
+        thread_id: Optional[str],
+        message_id: Optional[str],
+    ) -> Dict:
+        """
+        SaaS deduction: look up cost, deduct via ``credit_manager``.
+        """
+        cost = await self._get_tool_cost(tool_name)
+
+        if cost <= 0:
+            return {"success": True, "cost": 0, "reason": "free_tool"}
+
+        result = await credit_manager.deduct_credits(
+            account_id=account_id,
+            amount=cost,
+            description=f"Tool usage: {tool_name}",
+            type="tool_usage",
+            message_id=message_id,
+            thread_id=thread_id,
+        )
+
+        success = result.get("success", False)
+
+        if success:
+            logger.info(
+                f"[TOOL_BILLING] SaaS deducted ${cost:.4f} for tool '{tool_name}' "
+                f"(user={account_id})"
+            )
+            await invalidate_account_state_cache(account_id)
+        else:
+            logger.warning(
+                f"[TOOL_BILLING] SaaS deduction failed for tool '{tool_name}' "
+                f"(user={account_id}): {result.get('error')}"
+            )
+
+        return {
+            "success": success,
+            "cost": float(cost),
+            "new_balance": result.get("new_total", result.get("new_balance", 0)),
+            "transaction_id": result.get("transaction_id", result.get("ledger_id")),
+        }
+
+    async def _saas_can_use_tools_batch(
+        self, account_id: str, tool_names: List[str]
+    ) -> Dict:
+        """
+        SaaS batch pre-check: look up costs for all *tool_names* in one
+        query, sum them, and compare against the user's credit balance.
+        """
+        costs = await self._get_tool_costs_batch(tool_names)
+        total = sum(costs.values())
+
+        # All free -> pass immediately
+        if total <= 0:
+            return {"can_use": True, "total_cost": 0}
+
+        balance_info = await credit_manager.get_balance(account_id)
+        if isinstance(balance_info, dict):
+            balance = Decimal(str(balance_info.get("total", 0)))
+        else:
+            balance = Decimal(str(balance_info or 0))
+
+        can_use = balance >= total
+        return {
+            "can_use": can_use,
+            "total_cost": float(total),
+            "current_balance": float(balance),
+        }
+
+    # ================================================================== #
+    #  Helpers
+    # ================================================================== #
+
+    @staticmethod
+    async def _get_tool_costs_batch(tool_names: List[str]) -> Dict[str, Decimal]:
+        """
+        Look up per-invocation costs for all *tool_names* in a single
+        query.  Returns a dict mapping each tool name to its cost
+        (``Decimal('0')`` for tools not found or inactive).
+        """
+        # Initialise every requested tool to zero so callers always get a
+        # complete mapping even when the tool isn't in the table.
+        result_map: Dict[str, Decimal] = {name: Decimal("0") for name in tool_names}
+
+        try:
+            db = DBConnection()
+            client = await db.client
+            result = (
+                await client.table("tool_costs")
+                .select("tool_name, cost")
+                .in_("tool_name", tool_names)
+                .eq("is_active", True)
+                .execute()
+            )
+            if result.data:
+                for row in result.data:
+                    result_map[row["tool_name"]] = Decimal(str(row["cost"]))
+        except Exception as e:
+            logger.error(
+                f"[TOOL_BILLING] Failed to batch-look-up costs for "
+                f"tools {tool_names}: {e}"
+            )
+
+        return result_map
+
+    @staticmethod
+    async def _get_tool_cost(tool_name: str) -> Decimal:
+        """
+        Look up the per-invocation cost for *tool_name* from the
+        ``tool_costs`` table.  Returns ``Decimal('0')`` when the tool
+        is not found or is inactive.
+        """
+        try:
+            db = DBConnection()
+            client = await db.client
+            result = (
+                await client.table("tool_costs")
+                .select("cost")
+                .eq("tool_name", tool_name)
+                .eq("is_active", True)
+                .limit(1)
+                .execute()
+            )
+            if result.data:
+                return Decimal(str(result.data[0]["cost"]))
+        except Exception as e:
+            logger.error(f"[TOOL_BILLING] Failed to look up cost for tool '{tool_name}': {e}")
+
+        return Decimal("0")
+
+
+# Singleton -- import this wherever tool billing is needed.
+tool_billing_service = ToolBillingService()

--- a/backend/core/prompts/prompt.py
+++ b/backend/core/prompts/prompt.py
@@ -29,6 +29,12 @@ You are a full-spectrum autonomous agent capable of executing complex tasks acro
 - PERMISSIONS: sudo privileges enabled by default
 ## 2.3 OPERATIONAL CAPABILITIES
 You have the abilixwty to execute operations using both Python and CLI tools:
+
+### 2.3.0 TOOL COSTS
+- Some tools incur per-use costs. When a tool has a cost, it is shown in the tool's description (e.g., "Cost: $X.XX per use").
+- For any paid tool (cost > $0 in tool description), you MUST get explicit user confirmation before executing.
+- Treat paid tools with care: clarify intent, refine the request, then only execute after user confirms.
+
 ### 2.3.1 FILE OPERATIONS
 - Creating, reading, modifying, and deleting files
 - Organizing files into directories/folders
@@ -445,11 +451,10 @@ Images consume SIGNIFICANT context tokens (1000+ tokens per image). With a stric
 
 **🔴 CRITICAL: ALWAYS ASK FOR CONFIRMATION BEFORE USING THESE TOOLS 🔴**
 
-You have access to specialized research tools for finding people and companies. These tools are PAID and cost money per search, so you MUST always get explicit user confirmation before executing them.
+You have access to specialized research tools for finding people and companies. These tools are paid (cost shown in each tool's description), so you MUST always get explicit user confirmation before executing them.
 
 **PEOPLE SEARCH TOOL:**
 - **Purpose**: Find and research people with professional background information using natural language queries
-- **Cost**: $0.54 per search (returns 10 results)
 - **What it does**: Searches for people based on criteria like job title, company, location, skills, and enriches results with LinkedIn profiles
 - **When to use**: When users need to find specific professionals, potential candidates, leads, or research people in specific roles/companies
 
@@ -461,7 +466,7 @@ You have access to specialized research tools for finding people and companies. 
 **MANDATORY CLARIFICATION & CONFIRMATION WORKFLOW - NO EXCEPTIONS:**
 
 **STEP 1: ASK DETAILED CLARIFYING QUESTIONS (ALWAYS REQUIRED)**
-Before even thinking about confirming the search, you MUST ask clarifying questions to make the query as specific and targeted as possible. Each search costs $0.54, so precision is critical.
+Before even thinking about confirming the search, you MUST ask clarifying questions to make the query as specific and targeted as possible. These are paid tools, so precision is critical.
 
 **Required Clarification Areas for People Search:**
 - **Job Title/Role**: What specific role or title? (e.g., "engineer" vs "Senior Machine Learning Engineer")
@@ -484,7 +489,7 @@ Before even thinking about confirming the search, you MUST ask clarifying questi
 After getting clarification, construct a detailed, specific search query that incorporates all the details. Show the user the refined query you plan to use.
 
 **STEP 3: CONFIRM WITH COST**
-Only after clarifying and refining, ask for confirmation with cost clearly stated.
+Only after clarifying and refining, ask for confirmation. Include the cost from the tool description in your confirmation.
 
 **COMPLETE WORKFLOW:**
 1. **CLARIFY**: Ask 3-5 specific questions to understand exactly what they're looking for
@@ -516,12 +521,12 @@ Step 2: WAIT for user answers
 Step 3: REFINE - After user provides details, construct specific query:
 "Perfect! Based on your answers, I'll search for: 'Chief Technology Officers at Series A-B generative AI startups in San Francisco Bay Area with 20-100 employees and recent funding, preferably with ML engineering background'"
 
-Step 4: CONFIRM - Use 'ask' tool with refined query and cost:
+Step 4: CONFIRM - Use 'ask' tool with refined query and cost (check tool description for current cost):
 "Here's the refined search query I'll use:
 
 🔍 **Query**: 'Chief Technology Officers at Series A-B generative AI startups in San Francisco Bay Area with 20-100 employees and recent funding, preferably with ML engineering background'
 
-⚠️ **Cost**: $0.54 per search (returns up to 10 results with LinkedIn profiles and detailed professional information)
+⚠️ **Cost**: [Include cost from people_search tool description - e.g. "Cost: $X.XX per use"]
 
 This search will find CTOs matching your specific criteria. Would you like me to proceed?"
 
@@ -533,7 +538,7 @@ Step 6: Only if user confirms with "yes", then call people_search with the refin
 ```
 I can search for [description of search] using the [People/Company] Search tool.
 
-⚠️ Cost: $0.54 per search (returns 10 results)
+⚠️ Cost: [Include cost from the tool description - each paid tool shows its cost in its description]
 
 This will find [what they'll get from the search].
 
@@ -572,7 +577,7 @@ For Company Search:
 5. ⛔ NEVER use vague or general queries - always refine with user input first
 6. ✅ ALWAYS ask 3-5 clarifying questions before confirming
 7. ✅ ALWAYS show the refined query to the user before confirming
-8. ✅ ALWAYS explain the cost ($0.54 per search) in your confirmation request
+8. ✅ ALWAYS explain the cost (from tool description) in your confirmation request
 9. ✅ ALWAYS wait for explicit "yes" or confirmation from the user
 10. ✅ If user says no or hesitates, DO NOT proceed with the search
 11. ✅ After getting confirmation, execute the search and present results clearly
@@ -608,7 +613,7 @@ You (Step 2 - REFINE & CONFIRM): "Perfect! Here's the refined search I'll execut
 
 🔍 **Query**: 'Senior software engineers at Tesla working on autonomous driving and self-driving technology in Palo Alto, with Python and C++ expertise'
 
-⚠️ **Cost**: $0.54 per search (returns up to 10 results with LinkedIn profiles and detailed background)
+⚠️ **Cost**: [Include cost from people_search tool description]
 
 This will find senior autonomous driving engineers at Tesla matching your criteria. Would you like me to proceed?"
 
@@ -642,7 +647,7 @@ You (Step 2 - REFINE & CONFIRM): "Excellent! Here's the targeted search I'll run
 
 🔍 **Query**: 'Generative AI companies in San Francisco with Series A or Series B funding, 20-100 employees, building AI products'
 
-⚠️ **Cost**: $0.54 per search (returns up to 10 companies with enriched information including websites, funding details, and company profiles)
+⚠️ **Cost**: [Include cost from company_search tool description]
 
 This will find generative AI startups in San Francisco matching your specific criteria. Would you like me to proceed?"
 
@@ -672,10 +677,10 @@ These details will help me create a highly targeted search that finds exactly th
 ```
 
 **WHY CLARIFICATION IS CRITICAL:**
-- Each search costs $0.54 - precision saves money
+- These tools have per-use costs - precision saves money
 - Vague queries return irrelevant results, wasting the user's money
 - Specific queries yield better, more actionable results
-- You only get 10 results per search, so make them count
+- You only get limited results per search, so make them count
 - Better to spend 2 minutes clarifying than waste money on a bad search
 - Users appreciate thoroughness when their money is involved
 

--- a/backend/core/tools/company_search_tool.py
+++ b/backend/core/tools/company_search_tool.py
@@ -2,15 +2,12 @@ from typing import Optional
 import asyncio
 import structlog
 import json
-from decimal import Decimal
 from exa_py import Exa
 from exa_py.websets.types import CreateWebsetParameters, CreateEnrichmentParameters
 from core.agentpress.tool import Tool, ToolResult, openapi_schema, tool_metadata
 from core.utils.config import config, EnvMode
 from core.utils.logger import logger
 from core.agentpress.thread_manager import ThreadManager
-from core.billing.credits.manager import CreditManager
-from core.billing.shared.config import TOKEN_PRICE_MULTIPLIER
 from core.services.supabase import DBConnection
 
 @tool_metadata(
@@ -27,7 +24,6 @@ class CompanySearchTool(Tool):
         self.thread_manager = thread_manager
         self.api_key = config.EXA_API_KEY
         self.db = DBConnection()
-        self.credit_manager = CreditManager()
         self.exa_client = None
         
         if self.api_key:
@@ -53,29 +49,6 @@ class CompanySearchTool(Tool):
         except Exception as e:
             logger.error(f"Failed to get thread context: {e}")
         return None, None
-    
-    async def _deduct_credits(self, user_id: str, num_results: int, thread_id: Optional[str] = None) -> bool:
-        base_cost = Decimal('0.45')
-        total_cost = base_cost * TOKEN_PRICE_MULTIPLIER
-        
-        try:
-            result = await self.credit_manager.use_credits(
-                account_id=user_id,
-                amount=total_cost,
-                description=f"Company search: {num_results} results",
-                thread_id=thread_id
-            )
-            
-            if result.get('success'):
-                logger.info(f"Deducted ${total_cost:.2f} for company search ({num_results} results)")
-                return True
-            else:
-                logger.warning(f"Failed to deduct credits: {result.get('error')}")
-                return False
-                
-        except Exception as e:
-            logger.error(f"Error deducting credits: {e}")
-            return False
 
     @openapi_schema({
         "type": "function",
@@ -253,27 +226,10 @@ class CompanySearchTool(Tool):
                 }
                 
                 formatted_results.append(result_entry)
-            
-            base_cost = Decimal('0.45')
-            total_cost = base_cost * TOKEN_PRICE_MULTIPLIER
-            
-            if config.ENV_MODE == EnvMode.LOCAL:
-                logger.info("Running in LOCAL mode - skipping billing for company search")
-                cost_deducted_str = f"{int(total_cost * 100)} credits (LOCAL - not charged)"
-            else:
-                credits_deducted = await self._deduct_credits(user_id, len(formatted_results), thread_id)
-                if not credits_deducted:
-                    return self.fail_response(
-                        "Insufficient credits for company search. "
-                        f"This search costs {int(total_cost * 100)} credits ({len(formatted_results)} results). "
-                        "Please add credits to continue."
-                    )
-                cost_deducted_str = f"{int(total_cost * 100)} credits"
-            
+
             output = {
                 "query": query,
                 "total_results": len(formatted_results),
-                "cost_deducted": cost_deducted_str,
                 "results": formatted_results,
                 "enrichment_type": enrichment_description
             }

--- a/backend/core/tools/people_search_tool.py
+++ b/backend/core/tools/people_search_tool.py
@@ -2,15 +2,12 @@ from typing import Optional
 import asyncio
 import structlog
 import json
-from decimal import Decimal
 from exa_py import Exa
 from exa_py.websets.types import CreateWebsetParameters, CreateEnrichmentParameters
 from core.agentpress.tool import Tool, ToolResult, openapi_schema, tool_metadata
 from core.utils.config import config, EnvMode
 from core.utils.logger import logger
 from core.agentpress.thread_manager import ThreadManager
-from core.billing.credits.manager import CreditManager
-from core.billing.shared.config import TOKEN_PRICE_MULTIPLIER
 from core.services.supabase import DBConnection
 
 @tool_metadata(
@@ -27,7 +24,6 @@ class PeopleSearchTool(Tool):
         self.thread_manager = thread_manager
         self.api_key = config.EXA_API_KEY
         self.db = DBConnection()
-        self.credit_manager = CreditManager()
         self.exa_client = None
         
         if self.api_key:
@@ -53,29 +49,6 @@ class PeopleSearchTool(Tool):
         except Exception as e:
             logger.error(f"Failed to get thread context: {e}")
         return None, None
-    
-    async def _deduct_credits(self, user_id: str, num_results: int, thread_id: Optional[str] = None) -> bool:
-        base_cost = Decimal('0.45')
-        total_cost = base_cost * TOKEN_PRICE_MULTIPLIER
-        
-        try:
-            result = await self.credit_manager.use_credits(
-                account_id=user_id,
-                amount=total_cost,
-                description=f"People search: {num_results} results",
-                thread_id=thread_id
-            )
-            
-            if result.get('success'):
-                logger.info(f"Deducted ${total_cost:.2f} for people search ({num_results} results)")
-                return True
-            else:
-                logger.warning(f"Failed to deduct credits: {result.get('error')}")
-                return False
-                
-        except Exception as e:
-            logger.error(f"Error deducting credits: {e}")
-            return False
 
     @openapi_schema({
         "type": "function",
@@ -253,27 +226,10 @@ class PeopleSearchTool(Tool):
                 }
                 
                 formatted_results.append(result_entry)
-            
-            base_cost = Decimal('0.45')
-            total_cost = base_cost * TOKEN_PRICE_MULTIPLIER
-            
-            if config.ENV_MODE == EnvMode.LOCAL:
-                logger.info("Running in LOCAL mode - skipping billing for people search")
-                cost_deducted_str = f"{int(total_cost * 100)} credits (LOCAL - not charged)"
-            else:
-                credits_deducted = await self._deduct_credits(user_id, len(formatted_results), thread_id)
-                if not credits_deducted:
-                    return self.fail_response(
-                        "Insufficient credits for people search. "
-                        f"This search costs {int(total_cost * 100)} credits ({len(formatted_results)} results). "
-                        "Please add credits to continue."
-                    )
-                cost_deducted_str = f"{int(total_cost * 100)} credits"
-            
+
             output = {
                 "query": query,
                 "total_results": len(formatted_results),
-                "cost_deducted": cost_deducted_str,
                 "results": formatted_results,
                 "enrichment_type": enrichment_description
             }

--- a/backend/supabase/migrations/20260209101759_enterprise_usage_tool_cost_changes.sql
+++ b/backend/supabase/migrations/20260209101759_enterprise_usage_tool_cost_changes.sql
@@ -120,8 +120,10 @@ GRANT EXECUTE ON FUNCTION get_default_monthly_limit() TO authenticated;
 -- ============================================================================
 -- Tool costs table
 -- ============================================================================
+-- Drop and recreate so schema always matches this migration (seed data only).
+DROP TABLE IF EXISTS tool_costs;
 
-CREATE TABLE IF NOT EXISTS tool_costs (
+CREATE TABLE tool_costs (
     tool_name VARCHAR(255) PRIMARY KEY,
     cost NUMERIC(10, 6) NOT NULL DEFAULT 0 CHECK (cost >= 0::NUMERIC),
     description TEXT,

--- a/backend/supabase/migrations/20260209101759_enterprise_usage_tool_cost_changes.sql
+++ b/backend/supabase/migrations/20260209101759_enterprise_usage_tool_cost_changes.sql
@@ -1,0 +1,598 @@
+-- Enterprise Mode: Tool Cost Configuration & Global Settings
+-- Adds tool cost tracking, enterprise global settings, and functions
+-- for tool credit deduction and pre-flight checks.
+
+-- ============================================================================
+-- Enterprise global settings table
+-- ============================================================================
+-- Stores enterprise-wide configuration as key/value pairs (JSONB values).
+-- Used for defaults like monthly spending limits, notification thresholds, etc.
+
+CREATE TABLE IF NOT EXISTS public.enterprise_global_settings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    setting_key VARCHAR(255) NOT NULL UNIQUE,
+    setting_value JSONB NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    created_by UUID REFERENCES auth.users(id),
+    updated_by UUID REFERENCES auth.users(id),
+    CONSTRAINT enterprise_settings_key_not_empty CHECK (LENGTH(TRIM(setting_key)) > 0)
+);
+
+-- Index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_enterprise_global_settings_key
+    ON enterprise_global_settings(setting_key);
+
+-- Enable RLS
+ALTER TABLE enterprise_global_settings ENABLE ROW LEVEL SECURITY;
+
+-- Admin access policy (application layer validates admin role)
+DROP POLICY IF EXISTS "enterprise_global_settings_admin_access" ON enterprise_global_settings;
+CREATE POLICY "enterprise_global_settings_admin_access" ON enterprise_global_settings
+    FOR ALL USING (TRUE);
+
+-- Trigger for updated_at (reuses existing update_updated_at_column function)
+DROP TRIGGER IF EXISTS update_enterprise_global_settings_updated_at ON enterprise_global_settings;
+CREATE TRIGGER update_enterprise_global_settings_updated_at
+    BEFORE UPDATE ON enterprise_global_settings
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================================
+-- Seed default global settings
+-- ============================================================================
+
+INSERT INTO public.enterprise_global_settings (setting_key, setting_value, description)
+VALUES (
+    'default_monthly_limit',
+    '{"value": 100.0}',
+    'Default monthly spending limit for new enterprise users (in credits)'
+) ON CONFLICT (setting_key) DO NOTHING;
+
+INSERT INTO public.enterprise_global_settings (setting_key, setting_value, description)
+VALUES (
+    'default_settings',
+    '{"monthly_limit": 100.0, "allow_overages": false, "notification_threshold": 80.0}',
+    'Default settings applied to new enterprise users (values in credits)'
+) ON CONFLICT (setting_key) DO NOTHING;
+
+-- ============================================================================
+-- get_enterprise_setting - Look up a global setting by key
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS get_enterprise_setting(TEXT);
+
+CREATE OR REPLACE FUNCTION public.get_enterprise_setting(p_setting_key TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_result JSONB;
+BEGIN
+    SELECT egs.setting_value INTO v_result
+    FROM enterprise_global_settings egs
+    WHERE egs.setting_key = p_setting_key;
+
+    RETURN v_result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_enterprise_setting(TEXT) TO authenticated;
+
+-- ============================================================================
+-- get_default_monthly_limit - Resolve the default monthly limit
+-- ============================================================================
+-- Reads the 'default_monthly_limit' setting and extracts its numeric value (in credits).
+-- Falls back to 100.0 credits if the setting is missing or invalid.
+
+DROP FUNCTION IF EXISTS get_default_monthly_limit();
+
+CREATE OR REPLACE FUNCTION public.get_default_monthly_limit()
+RETURNS DECIMAL
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_result DECIMAL;
+    v_setting_value JSONB;
+BEGIN
+    SELECT get_enterprise_setting('default_monthly_limit') INTO v_setting_value;
+
+    -- Fallback to 100.0 if setting not found
+    IF v_setting_value IS NULL THEN
+        RETURN 100.0;
+    END IF;
+
+    v_result := (v_setting_value->>'value')::DECIMAL;
+
+    -- Ensure we have a valid positive value
+    IF v_result IS NULL OR v_result <= 0 THEN
+        RETURN 100.0;
+    END IF;
+
+    RETURN v_result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_default_monthly_limit() TO authenticated;
+
+-- ============================================================================
+-- Tool costs table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS tool_costs (
+    tool_name VARCHAR(255) PRIMARY KEY,
+    cost NUMERIC(10, 6) NOT NULL DEFAULT 0 CHECK (cost >= 0::NUMERIC),
+    description TEXT,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Seed default tool costs (by tool function name)
+-- Billing keys off tool_name from LLM tool calls
+INSERT INTO tool_costs (tool_name, cost, description, is_active)
+VALUES
+    -- ExpandMessageTool
+    ('expand_message', 0.0005, 'View full truncated message (ExpandMessageTool)', TRUE),
+    -- MessageTool
+    ('ask', 0.0005, 'Ask user question, wait response (MessageTool)', TRUE),
+    ('complete', 0.0005, 'Signal task completion to user (MessageTool)', TRUE),
+    ('wait', 0.0005, 'Pause execution for N seconds (MessageTool)', TRUE),
+    -- TaskListTool
+    ('view_tasks', 0.0010, 'View current task list (TaskListTool)', TRUE),
+    ('create_tasks', 0.0020, 'Create new tasks and sections (TaskListTool)', TRUE),
+    ('update_tasks', 0.0015, 'Update existing task content (TaskListTool)', TRUE),
+    ('delete_tasks', 0.0010, 'Delete tasks or sections (TaskListTool)', TRUE),
+    ('clear_all', 0.0010, 'Clear all tasks from list (TaskListTool)', TRUE),
+    -- SandboxShellTool
+    ('execute_command', 0.0100, 'Run shell command in workspace (SandboxShellTool)', TRUE),
+    ('check_command_output', 0.0020, 'Poll running command output (SandboxShellTool)', TRUE),
+    ('terminate_command', 0.0010, 'Kill running command session (SandboxShellTool)', TRUE),
+    ('list_commands', 0.0010, 'List active command sessions (SandboxShellTool)', TRUE),
+    -- SandboxFilesTool
+    ('create_file', 0.0050, 'Create new file with content (SandboxFilesTool)', TRUE),
+    ('str_replace', 0.0030, 'Find and replace in file (SandboxFilesTool)', TRUE),
+    ('full_file_rewrite', 0.0050, 'Overwrite entire file contents (SandboxFilesTool)', TRUE),
+    ('delete_file', 0.0020, 'Delete file from workspace (SandboxFilesTool)', TRUE),
+    ('edit_file', 0.0200, 'AI-assisted code edit via Morph (SandboxFilesTool)', TRUE),
+    -- SandboxExposeTool
+    ('expose_port', 0.0050, 'Share local port with preview URL (SandboxExposeTool)', TRUE),
+    -- SandboxVisionTool
+    ('load_image', 0.0300, 'Load image for vision context (SandboxVisionTool)', TRUE),
+    ('clear_images_from_context', 0.0010, 'Clear image context (SandboxVisionTool)', TRUE),
+    -- SandboxImageEditTool
+    ('image_edit_or_generate', 0.0800, 'Generate or edit images with AI (SandboxImageEditTool)', TRUE),
+    -- SandboxKbTool
+    ('init_kb', 0.0100, 'Initialize knowledge base (SandboxKbTool)', TRUE),
+    ('search_files', 0.0200, 'Semantic search in KB (SandboxKbTool)', TRUE),
+    ('cleanup_kb', 0.0050, 'Clean knowledge base data (SandboxKbTool)', TRUE),
+    ('ls_kb', 0.0020, 'List KB files and folders (SandboxKbTool)', TRUE),
+    ('global_kb_sync', 0.0150, 'Sync global KB to workspace (SandboxKbTool)', TRUE),
+    ('global_kb_create_folder', 0.0050, 'Create folder in global KB (SandboxKbTool)', TRUE),
+    ('global_kb_upload_file', 0.0150, 'Upload file to global KB (SandboxKbTool)', TRUE),
+    ('global_kb_delete_item', 0.0050, 'Delete item from global KB (SandboxKbTool)', TRUE),
+    ('global_kb_enable_item', 0.0030, 'Enable or disable KB item (SandboxKbTool)', TRUE),
+    ('global_kb_list_contents', 0.0050, 'List global KB contents (SandboxKbTool)', TRUE),
+    -- SandboxPresentationTool
+    ('list_templates', 0.0020, 'List presentation templates (SandboxPresentationTool)', TRUE),
+    ('load_template_design', 0.0100, 'Load template into presentation (SandboxPresentationTool)', TRUE),
+    ('create_slide', 0.0080, 'Create new presentation slide (SandboxPresentationTool)', TRUE),
+    ('list_slides', 0.0020, 'List slides in presentation (SandboxPresentationTool)', TRUE),
+    ('delete_slide', 0.0020, 'Delete slide from presentation (SandboxPresentationTool)', TRUE),
+    ('list_presentations', 0.0020, 'List all presentations (SandboxPresentationTool)', TRUE),
+    ('delete_presentation', 0.0030, 'Delete presentation (SandboxPresentationTool)', TRUE),
+    ('validate_slide', 0.0050, 'Validate slide content (SandboxPresentationTool)', TRUE),
+    ('export_to_pptx', 0.0200, 'Export presentation to PowerPoint (SandboxPresentationTool)', TRUE),
+    ('export_to_pdf', 0.0200, 'Export presentation to PDF (SandboxPresentationTool)', TRUE),
+    -- SandboxUploadFileTool
+    ('upload_file', 0.0200, 'Upload file to cloud storage (SandboxUploadFileTool)', TRUE),
+    -- SandboxWebSearchTool
+    ('web_search', 0.0300, 'Search web for information (SandboxWebSearchTool)', TRUE),
+    ('scrape_webpage', 0.0200, 'Scrape webpage content (SandboxWebSearchTool)', TRUE),
+    -- SandboxImageSearchTool
+    ('image_search', 0.0200, 'Search images on internet (SandboxImageSearchTool)', TRUE),
+    -- PeopleSearchTool
+    ('people_search', 0.0400, 'Search people professional info (PeopleSearchTool)', TRUE),
+    -- CompanySearchTool
+    ('company_search', 0.0400, 'Search companies business info (CompanySearchTool)', TRUE),
+    -- PaperSearchTool
+    ('paper_search', 0.0400, 'Search academic papers (PaperSearchTool)', TRUE),
+    ('get_paper_details', 0.0200, 'Get paper details by ID (PaperSearchTool)', TRUE),
+    ('search_authors', 0.0300, 'Search academic authors (PaperSearchTool)', TRUE),
+    ('get_author_details', 0.0200, 'Get author profile details (PaperSearchTool)', TRUE),
+    ('get_author_papers', 0.0300, 'Get papers by author (PaperSearchTool)', TRUE),
+    -- DataProvidersTool
+    ('get_data_provider_endpoints', 0.0010, 'List data provider endpoints (DataProvidersTool)', TRUE),
+    ('execute_data_provider_call', 0.0400, 'Call LinkedIn, Yahoo, etc (DataProvidersTool)', TRUE),
+    -- BrowserTool
+    ('browser_navigate_to', 0.0200, 'Navigate browser to URL (BrowserTool)', TRUE),
+    ('browser_act', 0.0250, 'Click, type, interact page (BrowserTool)', TRUE),
+    ('browser_extract_content', 0.0150, 'Extract content from page (BrowserTool)', TRUE),
+    ('browser_screenshot', 0.0300, 'Capture browser screenshot (BrowserTool)', TRUE),
+    -- VapiVoiceTool
+    ('make_phone_call', 0.1500, 'Initiate voice phone call (VapiVoiceTool)', TRUE),
+    ('end_call', 0.0100, 'End active phone call (VapiVoiceTool)', TRUE),
+    ('get_call_details', 0.0050, 'Get call status details (VapiVoiceTool)', TRUE),
+    ('wait_for_call_completion', 0.0200, 'Wait until call finishes (VapiVoiceTool)', TRUE),
+    ('list_calls', 0.0050, 'List recent voice calls (VapiVoiceTool)', TRUE),
+    -- AgentConfigTool
+    ('update_agent', 0.0100, 'Update agent config and tools (AgentConfigTool)', TRUE),
+    ('get_current_agent_config', 0.0020, 'Get current agent config (AgentConfigTool)', TRUE),
+    -- AgentCreationTool
+    ('create_new_agent', 0.0600, 'Create new AI agent (AgentCreationTool)', TRUE),
+    ('search_mcp_servers_for_agent', 0.0200, 'Search MCP servers for agent (AgentCreationTool)', TRUE),
+    ('get_mcp_server_details', 0.0100, 'Get MCP server details (AgentCreationTool)', TRUE),
+    ('create_credential_profile_for_agent', 0.0150, 'Create agent credential profile (AgentCreationTool)', TRUE),
+    ('discover_mcp_tools_for_agent', 0.0300, 'Discover tools from MCP (AgentCreationTool)', TRUE),
+    ('configure_agent_integration', 0.0200, 'Configure MCP integration (AgentCreationTool)', TRUE),
+    ('create_agent_scheduled_trigger', 0.0100, 'Create agent scheduled trigger (AgentCreationTool)', TRUE),
+    ('list_agent_scheduled_triggers', 0.0050, 'List agent triggers (AgentCreationTool)', TRUE),
+    ('toggle_agent_scheduled_trigger', 0.0050, 'Toggle agent trigger on/off (AgentCreationTool)', TRUE),
+    ('delete_agent_scheduled_trigger', 0.0050, 'Delete agent trigger (AgentCreationTool)', TRUE),
+    ('update_agent_config', 0.0150, 'Update agent configuration (AgentCreationTool)', TRUE),
+    -- MCPSearchTool
+    ('search_mcp_servers', 0.0200, 'Search MCP server catalog (MCPSearchTool)', TRUE),
+    ('get_app_details', 0.0100, 'Get MCP app details (MCPSearchTool)', TRUE),
+    ('discover_user_mcp_servers', 0.0300, 'Discover user MCP servers (MCPSearchTool)', TRUE),
+    -- CredentialProfileTool
+    ('get_credential_profiles', 0.0020, 'List credential profiles (CredentialProfileTool)', TRUE),
+    ('create_credential_profile', 0.0050, 'Create new credential profile (CredentialProfileTool)', TRUE),
+    ('configure_profile_for_agent', 0.0050, 'Link profile to agent (CredentialProfileTool)', TRUE),
+    ('delete_credential_profile', 0.0030, 'Delete credential profile (CredentialProfileTool)', TRUE),
+    -- TriggerTool
+    ('get_scheduled_triggers', 0.0050, 'List scheduled triggers (TriggerTool)', TRUE),
+    ('create_scheduled_trigger', 0.0100, 'Create scheduled trigger (TriggerTool)', TRUE),
+    ('delete_scheduled_trigger', 0.0050, 'Delete scheduled trigger (TriggerTool)', TRUE),
+    ('toggle_scheduled_trigger', 0.0050, 'Toggle trigger active state (TriggerTool)', TRUE),
+    ('list_event_trigger_apps', 0.0050, 'List event trigger apps (TriggerTool)', TRUE),
+    ('list_app_event_triggers', 0.0050, 'List app event triggers (TriggerTool)', TRUE),
+    ('create_event_trigger', 0.0100, 'Create event-based trigger (TriggerTool)', TRUE)
+ON CONFLICT (tool_name) DO UPDATE SET
+    cost = EXCLUDED.cost,
+    description = EXCLUDED.description,
+    is_active = EXCLUDED.is_active,
+    updated_at = NOW();
+
+-- ============================================================================
+-- Add tool usage columns to enterprise_usage
+-- ============================================================================
+
+ALTER TABLE enterprise_usage ADD COLUMN IF NOT EXISTS tool_name VARCHAR;
+ALTER TABLE enterprise_usage ADD COLUMN IF NOT EXISTS tool_cost NUMERIC(10, 6) DEFAULT 0 CHECK (tool_cost >= 0::NUMERIC);
+ALTER TABLE enterprise_usage ADD COLUMN IF NOT EXISTS usage_type VARCHAR DEFAULT 'token' CHECK (usage_type IN ('token', 'tool'));
+
+-- Allow NULL model_name for tool usage (tools have no model)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'enterprise_usage'
+          AND column_name = 'model_name'
+          AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE enterprise_usage ALTER COLUMN model_name DROP NOT NULL;
+    END IF;
+END $$;
+
+-- ============================================================================
+-- enterprise_can_use_tool - Pre-flight check for tool usage
+-- ============================================================================
+-- Read-only check that returns whether the user can afford to use a tool,
+-- without actually deducting anything. Useful for UI gating / pre-validation.
+
+DROP FUNCTION IF EXISTS enterprise_can_use_tool(UUID, VARCHAR);
+
+CREATE OR REPLACE FUNCTION public.enterprise_can_use_tool(
+    p_account_id UUID,
+    p_tool_name VARCHAR(255)
+)
+RETURNS TABLE(can_use BOOLEAN, required_cost DECIMAL, current_balance DECIMAL, user_remaining DECIMAL)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_tool_cost DECIMAL;
+    v_enterprise_balance DECIMAL;
+    v_monthly_limit DECIMAL;
+    v_current_usage DECIMAL;
+    v_user_remaining DECIMAL;
+    v_default_limit DECIMAL;
+BEGIN
+    -- Resolve the configurable default monthly limit
+    SELECT get_default_monthly_limit() INTO v_default_limit;
+
+    -- Get tool cost from tool_costs table
+    SELECT tc.cost INTO v_tool_cost
+    FROM tool_costs tc
+    WHERE tc.tool_name = p_tool_name AND tc.is_active = TRUE;
+
+    -- If no cost found or tool is free, check general enterprise status
+    IF v_tool_cost IS NULL OR v_tool_cost = 0 THEN
+        -- Get user's remaining allowance
+        SELECT eul.monthly_limit, eul.current_month_usage
+        INTO v_monthly_limit, v_current_usage
+        FROM enterprise_user_limits eul
+        WHERE eul.account_id = p_account_id AND eul.is_active = TRUE;
+
+        -- Use default if no limit set
+        IF v_monthly_limit IS NULL THEN
+            v_monthly_limit := v_default_limit;
+            v_current_usage := 0;
+        END IF;
+
+        v_user_remaining := v_monthly_limit - v_current_usage;
+
+        -- Get enterprise balance
+        SELECT eb.credit_balance INTO v_enterprise_balance
+        FROM enterprise_billing eb
+        WHERE eb.id = '00000000-0000-0000-0000-000000000000';
+
+        RETURN QUERY SELECT TRUE, COALESCE(v_tool_cost, 0::DECIMAL), v_enterprise_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- Get user's monthly limit and usage (no lock -- this is a read-only check)
+    SELECT eul.monthly_limit, eul.current_month_usage
+    INTO v_monthly_limit, v_current_usage
+    FROM enterprise_user_limits eul
+    WHERE eul.account_id = p_account_id AND eul.is_active = TRUE;
+
+    -- If no limit set, assume defaults (do NOT insert -- keep this read-only)
+    IF v_monthly_limit IS NULL THEN
+        v_monthly_limit := v_default_limit;
+        v_current_usage := 0;
+    END IF;
+
+    v_user_remaining := v_monthly_limit - v_current_usage;
+
+    -- Check if user has remaining monthly allowance for this tool
+    IF v_current_usage + v_tool_cost > v_monthly_limit THEN
+        SELECT eb.credit_balance INTO v_enterprise_balance
+        FROM enterprise_billing eb
+        WHERE eb.id = '00000000-0000-0000-0000-000000000000';
+
+        RETURN QUERY SELECT FALSE, v_tool_cost, v_enterprise_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- Get enterprise balance
+    SELECT eb.credit_balance INTO v_enterprise_balance
+    FROM enterprise_billing eb
+    WHERE eb.id = '00000000-0000-0000-0000-000000000000';
+
+    -- Check if enterprise has enough credit
+    IF v_enterprise_balance < v_tool_cost THEN
+        RETURN QUERY SELECT FALSE, v_tool_cost, v_enterprise_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- User can use the tool
+    RETURN QUERY SELECT TRUE, v_tool_cost, v_enterprise_balance, v_user_remaining;
+END;
+$$;
+
+-- Grant permission
+GRANT EXECUTE ON FUNCTION enterprise_can_use_tool(UUID, VARCHAR) TO authenticated;
+
+-- ============================================================================
+-- enterprise_use_tool_credits - Atomic tool credit deduction
+-- ============================================================================
+-- Looks up the tool cost from tool_costs, validates pool balance and user
+-- monthly limit, deducts credits, and logs the usage with usage_type = 'tool'.
+
+DROP FUNCTION IF EXISTS enterprise_use_tool_credits(UUID, VARCHAR, TEXT, TEXT);
+
+CREATE OR REPLACE FUNCTION public.enterprise_use_tool_credits(
+    p_account_id UUID,
+    p_tool_name VARCHAR(255),
+    p_thread_id TEXT DEFAULT NULL,
+    p_message_id TEXT DEFAULT NULL
+)
+RETURNS TABLE(success BOOLEAN, cost_charged DECIMAL, new_balance DECIMAL, user_remaining DECIMAL)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_tool_cost DECIMAL;
+    v_current_balance DECIMAL;
+    v_monthly_limit DECIMAL;
+    v_current_usage DECIMAL;
+    v_new_balance DECIMAL;
+    v_user_remaining DECIMAL;
+    v_default_limit DECIMAL;
+BEGIN
+    -- Resolve the configurable default monthly limit
+    SELECT get_default_monthly_limit() INTO v_default_limit;
+
+    -- Get tool cost (no lock needed -- tool_costs is a config table, rarely updated)
+    SELECT tc.cost INTO v_tool_cost
+    FROM tool_costs tc
+    WHERE tc.tool_name = p_tool_name AND tc.is_active = TRUE;
+
+    -- If no cost found or free tool, return success without locking
+    IF v_tool_cost IS NULL OR v_tool_cost = 0 THEN
+        SELECT eul.monthly_limit, eul.current_month_usage
+        INTO v_monthly_limit, v_current_usage
+        FROM enterprise_user_limits eul
+        WHERE eul.account_id = p_account_id AND eul.is_active = TRUE;
+
+        IF v_monthly_limit IS NULL THEN
+            v_monthly_limit := v_default_limit;
+            v_current_usage := 0;
+        END IF;
+
+        v_user_remaining := v_monthly_limit - v_current_usage;
+
+        SELECT eb.credit_balance INTO v_current_balance
+        FROM enterprise_billing eb
+        WHERE eb.id = '00000000-0000-0000-0000-000000000000';
+
+        RETURN QUERY SELECT TRUE, 0::DECIMAL, v_current_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- Lock and get the enterprise pool balance (serializes concurrent deductions)
+    SELECT eb.credit_balance INTO v_current_balance
+    FROM enterprise_billing eb
+    WHERE eb.id = '00000000-0000-0000-0000-000000000000'
+    FOR UPDATE;
+
+    IF v_current_balance IS NULL THEN
+        RETURN QUERY SELECT FALSE, 0::DECIMAL, 0::DECIMAL, 0::DECIMAL;
+        RETURN;
+    END IF;
+
+    -- Lock and get user limits (serializes concurrent deductions for this user)
+    SELECT eul.monthly_limit, eul.current_month_usage
+    INTO v_monthly_limit, v_current_usage
+    FROM enterprise_user_limits eul
+    WHERE eul.account_id = p_account_id AND eul.is_active = TRUE
+    FOR UPDATE;
+
+    -- If no limit set, create default
+    IF v_monthly_limit IS NULL THEN
+        INSERT INTO enterprise_user_limits (account_id)
+        VALUES (p_account_id)
+        ON CONFLICT (account_id) DO UPDATE SET is_active = TRUE;
+
+        v_monthly_limit := v_default_limit;
+        v_current_usage := 0;
+    END IF;
+
+    v_user_remaining := v_monthly_limit - v_current_usage;
+
+    -- Check monthly limit
+    IF v_current_usage + v_tool_cost > v_monthly_limit THEN
+        RETURN QUERY SELECT FALSE, 0::DECIMAL, v_current_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- Check sufficient pool balance
+    IF v_current_balance < v_tool_cost THEN
+        RETURN QUERY SELECT FALSE, 0::DECIMAL, v_current_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- All checks passed with locks held -- deduct from enterprise balance
+    UPDATE enterprise_billing
+    SET credit_balance = credit_balance - v_tool_cost,
+        total_used = total_used + v_tool_cost,
+        updated_at = NOW()
+    WHERE id = '00000000-0000-0000-0000-000000000000'
+    RETURNING credit_balance INTO v_new_balance;
+
+    -- Update user's monthly usage
+    UPDATE enterprise_user_limits
+    SET current_month_usage = current_month_usage + v_tool_cost,
+        updated_at = NOW()
+    WHERE account_id = p_account_id;
+
+    -- Log tool usage (no model_name for tools, set cost and tool_cost to same value)
+    INSERT INTO enterprise_usage (
+        account_id, thread_id, message_id, cost, tool_name, tool_cost, usage_type, model_name
+    ) VALUES (
+        p_account_id, p_thread_id, p_message_id, v_tool_cost, p_tool_name, v_tool_cost, 'tool', NULL
+    );
+
+    v_user_remaining := v_user_remaining - v_tool_cost;
+
+    RETURN QUERY SELECT TRUE, v_tool_cost, v_new_balance, v_user_remaining;
+END;
+$$;
+
+-- Grant permission
+GRANT EXECUTE ON FUNCTION enterprise_use_tool_credits(UUID, VARCHAR, TEXT, TEXT) TO authenticated;
+
+-- ============================================================================
+-- enterprise_can_use_tools_batch - Batch pre-flight check for multiple tools
+-- ============================================================================
+-- Read-only check that sums the cost of all requested tools and validates
+-- the user's monthly allowance and enterprise pool balance against the total.
+-- More efficient than N individual enterprise_can_use_tool calls.
+
+DROP FUNCTION IF EXISTS enterprise_can_use_tools_batch(UUID, VARCHAR[]);
+
+CREATE OR REPLACE FUNCTION public.enterprise_can_use_tools_batch(
+    p_account_id UUID,
+    p_tool_names VARCHAR[]
+)
+RETURNS TABLE(
+    can_use BOOLEAN,
+    total_cost DECIMAL,
+    current_balance DECIMAL,
+    user_remaining DECIMAL
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_total_cost DECIMAL := 0;
+    v_enterprise_balance DECIMAL;
+    v_monthly_limit DECIMAL;
+    v_current_usage DECIMAL;
+    v_user_remaining DECIMAL;
+    v_default_limit DECIMAL;
+BEGIN
+    -- Resolve the configurable default monthly limit
+    SELECT get_default_monthly_limit() INTO v_default_limit;
+
+    -- Sum the cost of all requested (active) tools in a single query.
+    -- Tools not found in tool_costs are treated as free (cost = 0).
+    SELECT COALESCE(SUM(tc.cost), 0)
+    INTO v_total_cost
+    FROM unnest(p_tool_names) AS requested(name)
+    JOIN tool_costs tc ON tc.tool_name = requested.name AND tc.is_active = TRUE;
+
+    -- Get user's monthly limit and current usage (read-only, no lock)
+    SELECT eul.monthly_limit, eul.current_month_usage
+    INTO v_monthly_limit, v_current_usage
+    FROM enterprise_user_limits eul
+    WHERE eul.account_id = p_account_id AND eul.is_active = TRUE;
+
+    IF v_monthly_limit IS NULL THEN
+        v_monthly_limit := v_default_limit;
+        v_current_usage := 0;
+    END IF;
+
+    v_user_remaining := v_monthly_limit - v_current_usage;
+
+    -- If total cost is zero (all free / unknown tools), pass immediately
+    IF v_total_cost = 0 THEN
+        SELECT eb.credit_balance INTO v_enterprise_balance
+        FROM enterprise_billing eb
+        WHERE eb.id = '00000000-0000-0000-0000-000000000000';
+
+        RETURN QUERY SELECT TRUE, v_total_cost, v_enterprise_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- Validate user monthly allowance
+    IF v_current_usage + v_total_cost > v_monthly_limit THEN
+        SELECT eb.credit_balance INTO v_enterprise_balance
+        FROM enterprise_billing eb
+        WHERE eb.id = '00000000-0000-0000-0000-000000000000';
+
+        RETURN QUERY SELECT FALSE, v_total_cost, v_enterprise_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- Validate enterprise pool balance
+    SELECT eb.credit_balance INTO v_enterprise_balance
+    FROM enterprise_billing eb
+    WHERE eb.id = '00000000-0000-0000-0000-000000000000';
+
+    IF v_enterprise_balance < v_total_cost THEN
+        RETURN QUERY SELECT FALSE, v_total_cost, v_enterprise_balance, v_user_remaining;
+        RETURN;
+    END IF;
+
+    -- All checks passed
+    RETURN QUERY SELECT TRUE, v_total_cost, v_enterprise_balance, v_user_remaining;
+END;
+$$;
+
+-- Grant permission
+GRANT EXECUTE ON FUNCTION enterprise_can_use_tools_batch(UUID, VARCHAR[]) TO authenticated;

--- a/backend/supabase/migrations/20260209101759_enterprise_usage_tool_cost_changes.sql
+++ b/backend/supabase/migrations/20260209101759_enterprise_usage_tool_cost_changes.sql
@@ -133,124 +133,30 @@ CREATE TABLE tool_costs (
 );
 
 -- Seed default tool costs (by tool function name)
--- Billing keys off tool_name from LLM tool calls
+-- Only these 21 tools are billed; all other tools are treated as free (not in table = cost 0).
 INSERT INTO tool_costs (tool_name, cost, description, is_active)
 VALUES
-    -- ExpandMessageTool
-    ('expand_message', 0.0005, 'View full truncated message (ExpandMessageTool)', TRUE),
-    -- MessageTool
-    ('ask', 0.0005, 'Ask user question, wait response (MessageTool)', TRUE),
-    ('complete', 0.0005, 'Signal task completion to user (MessageTool)', TRUE),
-    ('wait', 0.0005, 'Pause execution for N seconds (MessageTool)', TRUE),
-    -- TaskListTool
-    ('view_tasks', 0.0010, 'View current task list (TaskListTool)', TRUE),
-    ('create_tasks', 0.0020, 'Create new tasks and sections (TaskListTool)', TRUE),
-    ('update_tasks', 0.0015, 'Update existing task content (TaskListTool)', TRUE),
-    ('delete_tasks', 0.0010, 'Delete tasks or sections (TaskListTool)', TRUE),
-    ('clear_all', 0.0010, 'Clear all tasks from list (TaskListTool)', TRUE),
-    -- SandboxShellTool
-    ('execute_command', 0.0100, 'Run shell command in workspace (SandboxShellTool)', TRUE),
-    ('check_command_output', 0.0020, 'Poll running command output (SandboxShellTool)', TRUE),
-    ('terminate_command', 0.0010, 'Kill running command session (SandboxShellTool)', TRUE),
-    ('list_commands', 0.0010, 'List active command sessions (SandboxShellTool)', TRUE),
-    -- SandboxFilesTool
-    ('create_file', 0.0050, 'Create new file with content (SandboxFilesTool)', TRUE),
-    ('str_replace', 0.0030, 'Find and replace in file (SandboxFilesTool)', TRUE),
-    ('full_file_rewrite', 0.0050, 'Overwrite entire file contents (SandboxFilesTool)', TRUE),
-    ('delete_file', 0.0020, 'Delete file from workspace (SandboxFilesTool)', TRUE),
-    ('edit_file', 0.0200, 'AI-assisted code edit via Morph (SandboxFilesTool)', TRUE),
-    -- SandboxExposeTool
-    ('expose_port', 0.0050, 'Share local port with preview URL (SandboxExposeTool)', TRUE),
-    -- SandboxVisionTool
-    ('load_image', 0.0300, 'Load image for vision context (SandboxVisionTool)', TRUE),
-    ('clear_images_from_context', 0.0010, 'Clear image context (SandboxVisionTool)', TRUE),
-    -- SandboxImageEditTool
-    ('image_edit_or_generate', 0.0800, 'Generate or edit images with AI (SandboxImageEditTool)', TRUE),
-    -- SandboxKbTool
-    ('init_kb', 0.0100, 'Initialize knowledge base (SandboxKbTool)', TRUE),
-    ('search_files', 0.0200, 'Semantic search in KB (SandboxKbTool)', TRUE),
-    ('cleanup_kb', 0.0050, 'Clean knowledge base data (SandboxKbTool)', TRUE),
-    ('ls_kb', 0.0020, 'List KB files and folders (SandboxKbTool)', TRUE),
-    ('global_kb_sync', 0.0150, 'Sync global KB to workspace (SandboxKbTool)', TRUE),
-    ('global_kb_create_folder', 0.0050, 'Create folder in global KB (SandboxKbTool)', TRUE),
-    ('global_kb_upload_file', 0.0150, 'Upload file to global KB (SandboxKbTool)', TRUE),
-    ('global_kb_delete_item', 0.0050, 'Delete item from global KB (SandboxKbTool)', TRUE),
-    ('global_kb_enable_item', 0.0030, 'Enable or disable KB item (SandboxKbTool)', TRUE),
-    ('global_kb_list_contents', 0.0050, 'List global KB contents (SandboxKbTool)', TRUE),
-    -- SandboxPresentationTool
-    ('list_templates', 0.0020, 'List presentation templates (SandboxPresentationTool)', TRUE),
-    ('load_template_design', 0.0100, 'Load template into presentation (SandboxPresentationTool)', TRUE),
-    ('create_slide', 0.0080, 'Create new presentation slide (SandboxPresentationTool)', TRUE),
-    ('list_slides', 0.0020, 'List slides in presentation (SandboxPresentationTool)', TRUE),
-    ('delete_slide', 0.0020, 'Delete slide from presentation (SandboxPresentationTool)', TRUE),
-    ('list_presentations', 0.0020, 'List all presentations (SandboxPresentationTool)', TRUE),
-    ('delete_presentation', 0.0030, 'Delete presentation (SandboxPresentationTool)', TRUE),
-    ('validate_slide', 0.0050, 'Validate slide content (SandboxPresentationTool)', TRUE),
-    ('export_to_pptx', 0.0200, 'Export presentation to PowerPoint (SandboxPresentationTool)', TRUE),
-    ('export_to_pdf', 0.0200, 'Export presentation to PDF (SandboxPresentationTool)', TRUE),
-    -- SandboxUploadFileTool
-    ('upload_file', 0.0200, 'Upload file to cloud storage (SandboxUploadFileTool)', TRUE),
-    -- SandboxWebSearchTool
-    ('web_search', 0.0300, 'Search web for information (SandboxWebSearchTool)', TRUE),
-    ('scrape_webpage', 0.0200, 'Scrape webpage content (SandboxWebSearchTool)', TRUE),
-    -- SandboxImageSearchTool
-    ('image_search', 0.0200, 'Search images on internet (SandboxImageSearchTool)', TRUE),
-    -- PeopleSearchTool
-    ('people_search', 0.0400, 'Search people professional info (PeopleSearchTool)', TRUE),
-    -- CompanySearchTool
-    ('company_search', 0.0400, 'Search companies business info (CompanySearchTool)', TRUE),
-    -- PaperSearchTool
-    ('paper_search', 0.0400, 'Search academic papers (PaperSearchTool)', TRUE),
-    ('get_paper_details', 0.0200, 'Get paper details by ID (PaperSearchTool)', TRUE),
-    ('search_authors', 0.0300, 'Search academic authors (PaperSearchTool)', TRUE),
-    ('get_author_details', 0.0200, 'Get author profile details (PaperSearchTool)', TRUE),
-    ('get_author_papers', 0.0300, 'Get papers by author (PaperSearchTool)', TRUE),
-    -- DataProvidersTool
-    ('get_data_provider_endpoints', 0.0010, 'List data provider endpoints (DataProvidersTool)', TRUE),
-    ('execute_data_provider_call', 0.0400, 'Call LinkedIn, Yahoo, etc (DataProvidersTool)', TRUE),
-    -- BrowserTool
-    ('browser_navigate_to', 0.0200, 'Navigate browser to URL (BrowserTool)', TRUE),
-    ('browser_act', 0.0250, 'Click, type, interact page (BrowserTool)', TRUE),
-    ('browser_extract_content', 0.0150, 'Extract content from page (BrowserTool)', TRUE),
-    ('browser_screenshot', 0.0300, 'Capture browser screenshot (BrowserTool)', TRUE),
-    -- VapiVoiceTool
-    ('make_phone_call', 0.1500, 'Initiate voice phone call (VapiVoiceTool)', TRUE),
-    ('end_call', 0.0100, 'End active phone call (VapiVoiceTool)', TRUE),
-    ('get_call_details', 0.0050, 'Get call status details (VapiVoiceTool)', TRUE),
-    ('wait_for_call_completion', 0.0200, 'Wait until call finishes (VapiVoiceTool)', TRUE),
-    ('list_calls', 0.0050, 'List recent voice calls (VapiVoiceTool)', TRUE),
-    -- AgentConfigTool
-    ('update_agent', 0.0100, 'Update agent config and tools (AgentConfigTool)', TRUE),
-    ('get_current_agent_config', 0.0020, 'Get current agent config (AgentConfigTool)', TRUE),
-    -- AgentCreationTool
-    ('create_new_agent', 0.0600, 'Create new AI agent (AgentCreationTool)', TRUE),
-    ('search_mcp_servers_for_agent', 0.0200, 'Search MCP servers for agent (AgentCreationTool)', TRUE),
-    ('get_mcp_server_details', 0.0100, 'Get MCP server details (AgentCreationTool)', TRUE),
-    ('create_credential_profile_for_agent', 0.0150, 'Create agent credential profile (AgentCreationTool)', TRUE),
-    ('discover_mcp_tools_for_agent', 0.0300, 'Discover tools from MCP (AgentCreationTool)', TRUE),
-    ('configure_agent_integration', 0.0200, 'Configure MCP integration (AgentCreationTool)', TRUE),
-    ('create_agent_scheduled_trigger', 0.0100, 'Create agent scheduled trigger (AgentCreationTool)', TRUE),
-    ('list_agent_scheduled_triggers', 0.0050, 'List agent triggers (AgentCreationTool)', TRUE),
-    ('toggle_agent_scheduled_trigger', 0.0050, 'Toggle agent trigger on/off (AgentCreationTool)', TRUE),
-    ('delete_agent_scheduled_trigger', 0.0050, 'Delete agent trigger (AgentCreationTool)', TRUE),
-    ('update_agent_config', 0.0150, 'Update agent configuration (AgentCreationTool)', TRUE),
-    -- MCPSearchTool
-    ('search_mcp_servers', 0.0200, 'Search MCP server catalog (MCPSearchTool)', TRUE),
-    ('get_app_details', 0.0100, 'Get MCP app details (MCPSearchTool)', TRUE),
-    ('discover_user_mcp_servers', 0.0300, 'Discover user MCP servers (MCPSearchTool)', TRUE),
-    -- CredentialProfileTool
-    ('get_credential_profiles', 0.0020, 'List credential profiles (CredentialProfileTool)', TRUE),
-    ('create_credential_profile', 0.0050, 'Create new credential profile (CredentialProfileTool)', TRUE),
-    ('configure_profile_for_agent', 0.0050, 'Link profile to agent (CredentialProfileTool)', TRUE),
-    ('delete_credential_profile', 0.0030, 'Delete credential profile (CredentialProfileTool)', TRUE),
-    -- TriggerTool
-    ('get_scheduled_triggers', 0.0050, 'List scheduled triggers (TriggerTool)', TRUE),
-    ('create_scheduled_trigger', 0.0100, 'Create scheduled trigger (TriggerTool)', TRUE),
-    ('delete_scheduled_trigger', 0.0050, 'Delete scheduled trigger (TriggerTool)', TRUE),
-    ('toggle_scheduled_trigger', 0.0050, 'Toggle trigger active state (TriggerTool)', TRUE),
-    ('list_event_trigger_apps', 0.0050, 'List event trigger apps (TriggerTool)', TRUE),
-    ('list_app_event_triggers', 0.0050, 'List app event triggers (TriggerTool)', TRUE),
-    ('create_event_trigger', 0.0100, 'Create event-based trigger (TriggerTool)', TRUE)
+    ('browser_act', 0.025000, 'Click, type, interact page (BrowserTool)', TRUE),
+    ('browser_extract_content', 0.025000, 'Extract content from page (BrowserTool)', TRUE),
+    ('browser_navigate_to', 0.020000, 'Navigate browser to URL (BrowserTool)', TRUE),
+    ('browser_screenshot', 0.030000, 'Capture browser screenshot (BrowserTool)', TRUE),
+    ('company_search', 0.100000, 'Search companies business info (CompanySearchTool)', TRUE),
+    ('complete', 0.000500, 'Signal task completion to user (MessageTool)', TRUE),
+    ('create_slide', 0.100000, 'Create new presentation slide (SandboxPresentationTool)', TRUE),
+    ('edit_file', 0.020000, 'AI-assisted code edit via Morph (SandboxFilesTool)', TRUE),
+    ('execute_data_provider_call', 0.040000, 'Call LinkedIn, Yahoo, etc (DataProvidersTool)', TRUE),
+    ('get_author_papers', 0.200000, 'Get papers by author (PaperSearchTool)', TRUE),
+    ('get_call_details', 0.100000, 'Get call status details (VapiVoiceTool)', TRUE),
+    ('get_paper_details', 0.200000, 'Get paper details by ID (PaperSearchTool)', TRUE),
+    ('image_edit_or_generate', 0.200000, 'Generate or edit images with AI (SandboxImageEditTool)', TRUE),
+    ('image_search', 0.200000, 'Search images on internet (SandboxImageSearchTool)', TRUE),
+    ('make_phone_call', 0.150000, 'Initiate voice phone call (VapiVoiceTool)', TRUE),
+    ('paper_search', 0.100000, 'Search academic papers (PaperSearchTool)', TRUE),
+    ('people_search', 0.100000, 'Search people professional info (PeopleSearchTool)', TRUE),
+    ('scrape_webpage', 0.100000, 'Scrape webpage content (SandboxWebSearchTool)', TRUE),
+    ('search_authors', 0.100000, 'Search academic authors (PaperSearchTool)', TRUE),
+    ('search_files', 0.020000, 'Semantic search in KB (SandboxKbTool)', TRUE),
+    ('web_search', 0.050000, 'Search web for information (SandboxWebSearchTool)', TRUE)
 ON CONFLICT (tool_name) DO UPDATE SET
     cost = EXCLUDED.cost,
     description = EXCLUDED.description,

--- a/frontend/src/components/billing/daily-usage-logs.tsx
+++ b/frontend/src/components/billing/daily-usage-logs.tsx
@@ -1,0 +1,348 @@
+'use client';
+
+import { useState } from 'react';
+import { format } from 'date-fns';
+import type { DateRange } from 'react-day-picker';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Skeleton } from '@/components/ui/skeleton';
+import { DateRangePicker } from '@/components/ui/date-range-picker';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertCircle, ChevronDown, ChevronRight, ExternalLink, TrendingDown } from 'lucide-react';
+import { useCreditUsageDetail } from '@/hooks/billing/use-credit-usage-detail';
+import { formatCredits } from '@/lib/utils/credit-formatter';
+import { isEnterpriseMode } from '@/lib/config';
+import type { DayUsage, ThreadUsageDetail, UsageRecord } from '@/hooks/billing/use-credit-usage-detail';
+
+function TypeBadge({ typeDisplay }: { typeDisplay: string }) {
+  const isTool = typeDisplay.startsWith('Tool - ');
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${
+        isTool ? 'bg-destructive/10 text-destructive' : 'bg-muted text-muted-foreground'
+      }`}
+    >
+      {typeDisplay}
+    </span>
+  );
+}
+
+function ThreadRow({
+  thread,
+  useDollars,
+  onThreadClick,
+}: {
+  thread: ThreadUsageDetail;
+  useDollars: boolean;
+  onThreadClick: (threadId: string, projectId: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const totalDisplay = useDollars
+    ? `$${thread.total_cost.toFixed(2)}`
+    : formatCredits(thread.total_credits);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="rounded-lg border bg-card">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between p-4 text-left hover:bg-muted/50 transition-colors rounded-lg"
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              {open ? (
+                <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+              <span className="font-medium truncate">{thread.project_name}</span>
+              <button
+                type="button"
+                className="p-1 -m-1 rounded hover:bg-muted"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  onThreadClick(thread.thread_id, thread.project_id);
+                }}
+              >
+                <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
+              </button>
+            </div>
+            <div className="flex flex-col items-end shrink-0">
+              <span className="font-medium tabular-nums">{totalDisplay}</span>
+              <span className="text-xs text-muted-foreground">
+                {formatCredits(thread.total_credits)} credits
+              </span>
+            </div>
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="border-t px-4 pb-4 pt-2">
+            <Table>
+              <TableHeader>
+                <TableRow className="hover:bg-transparent border-b">
+                  <TableHead className="w-[100px]">Time</TableHead>
+                  <TableHead className="w-[140px]">Type</TableHead>
+                  <TableHead className="text-right">Prompt</TableHead>
+                  <TableHead className="text-right">Completion</TableHead>
+                  <TableHead className="text-right">Tool</TableHead>
+                  <TableHead className="text-right">Total Cost</TableHead>
+                  <TableHead className="text-right">Credits</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {thread.usage_records.map((record: UsageRecord, idx: number) => (
+                  <TableRow key={idx}>
+                    <TableCell className="font-mono text-sm">{record.time}</TableCell>
+                    <TableCell>
+                      <TypeBadge typeDisplay={record.type_display} />
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {record.prompt_tokens.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {record.completion_tokens.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {record.tool_cost > 0
+                        ? useDollars
+                          ? `$${record.tool_cost.toFixed(2)}`
+                          : formatCredits(Math.round(record.tool_cost * 100))
+                        : '0'}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums font-medium">
+                      {useDollars ? `$${record.total_cost.toFixed(2)}` : formatCredits(record.credits)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatCredits(record.credits)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+function DaySection({
+  day,
+  useDollars,
+  onThreadClick,
+}: {
+  day: DayUsage;
+  useDollars: boolean;
+  onThreadClick: (threadId: string, projectId: string | null) => void;
+}) {
+  const [open, setOpen] = useState(true);
+  const totalDisplay = useDollars
+    ? `$${day.total_cost.toFixed(2)}`
+    : formatCredits(day.total_credits);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="rounded-xl border bg-card overflow-hidden">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between p-4 hover:bg-muted/30 transition-colors"
+          >
+            <div className="flex items-center gap-2">
+              {open ? (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              )}
+              <span className="font-semibold">{day.date_display}</span>
+            </div>
+            <div className="flex flex-col items-end">
+              <span className="font-semibold tabular-nums">{totalDisplay}</span>
+              <span className="text-xs text-muted-foreground">
+                {formatCredits(day.total_credits)} credits
+              </span>
+            </div>
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="space-y-2 px-4 pb-4">
+            {day.threads.map((thread) => (
+              <ThreadRow
+                key={thread.thread_id}
+                thread={thread}
+                useDollars={useDollars}
+                onThreadClick={onThreadClick}
+              />
+            ))}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+export default function DailyUsageLogs() {
+  const [dateRange, setDateRange] = useState<DateRange>({
+    from: new Date(new Date().setDate(new Date().getDate() - 29)),
+    to: new Date(),
+  });
+
+  const { data, isLoading, error } = useCreditUsageDetail({
+    startDate: dateRange?.from,
+    endDate: dateRange?.to,
+  });
+
+  const useDollars = isEnterpriseMode();
+
+  const handleThreadClick = (threadId: string, projectId: string | null) => {
+    if (projectId) {
+      window.open(`/projects/${projectId}/thread/${threadId}`, '_blank');
+    }
+  };
+
+  const handleDateRangeUpdate = (values: { range: DateRange }) => {
+    setDateRange(values.range);
+  };
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Daily Usage Logs</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>
+              {error.message || 'Failed to load usage details'}
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>Daily Usage Logs</CardTitle>
+                <CardDescription className="mt-1">
+                  Per-cost breakdown of prompt and tool usage by project
+                </CardDescription>
+              </div>
+              <Skeleton className="h-10 w-[280px]" />
+            </div>
+          </CardHeader>
+        </Card>
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const dailyUsage = data?.daily_usage || [];
+  const summary = data?.summary;
+
+  return (
+    <div className="space-y-6 min-w-0 max-w-full">
+      {summary && (
+        <Card className="w-full">
+          <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div>
+              <CardTitle className="text-base sm:text-lg">Total Usage</CardTitle>
+              <CardDescription className="mt-1 sm:mt-2 text-xs sm:text-sm">
+                {dateRange.from && dateRange.to
+                  ? `${format(dateRange.from, 'MMM dd, yyyy')} - ${format(dateRange.to, 'MMM dd, yyyy')}`
+                  : 'Selected period'}
+              </CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <TrendingDown className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground flex-shrink-0" />
+              <div>
+                <div className="text-xl sm:text-3xl font-semibold">
+                  {useDollars
+                    ? `$${summary.total_cost.toFixed(2)}`
+                    : formatCredits(summary.total_credits_used)}
+                </div>
+                <p className="text-xs sm:text-sm text-muted-foreground">
+                  {useDollars ? 'Amount consumed' : 'Credits consumed'}
+                </p>
+              </div>
+            </div>
+          </CardHeader>
+        </Card>
+      )}
+
+      <Card className="p-0 bg-transparent shadow-none border-none">
+        <CardHeader className="px-0">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div>
+              <CardTitle className="text-base sm:text-lg">Daily Usage Logs</CardTitle>
+              <CardDescription className="mt-1 sm:mt-2 text-xs sm:text-sm">
+                Per-cost breakdown of prompt and tool usage within each project
+              </CardDescription>
+            </div>
+            <DateRangePicker
+              initialDateFrom={dateRange.from}
+              initialDateTo={dateRange.to}
+              onUpdate={handleDateRangeUpdate}
+              align="end"
+            />
+          </div>
+        </CardHeader>
+        <CardContent className="px-0">
+          {dailyUsage.length === 0 ? (
+            <div className="text-center py-12 rounded-xl border bg-muted/20">
+              <p className="text-muted-foreground text-sm">
+                {dateRange.from && dateRange.to
+                  ? `No usage found between ${format(dateRange.from, 'MMM dd, yyyy')} and ${format(
+                      dateRange.to,
+                      'MMM dd, yyyy'
+                    )}.`
+                  : 'No usage found.'}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {dailyUsage.map((day) => (
+                <DaySection
+                  key={day.date}
+                  day={day}
+                  useDollars={useDollars}
+                  onThreadClick={handleThreadClick}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/user-settings-modal.tsx
+++ b/frontend/src/components/settings/user-settings-modal.tsx
@@ -80,7 +80,7 @@ import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle } 
 import { getPlanName, getPlanIcon } from '../billing/plan-utils';
 import { TierBadge } from '../billing/tier-badge';
 import { siteConfig } from '@/lib/home';
-import ThreadUsage from '@/components/billing/thread-usage';
+import DailyUsageLogs from '@/components/billing/daily-usage-logs';
 import { formatCredits } from '@/lib/utils/credit-formatter';
 import { LanguageSwitcher } from './language-switcher';
 import { useTranslations } from 'next-intl';
@@ -1156,7 +1156,7 @@ function CreditsHelpAlert() {
 function UsageTab() {
     return (
         <div className="p-4 sm:p-6 space-y-5 sm:space-y-6 min-w-0 max-w-full overflow-x-hidden">
-            <ThreadUsage />
+            <DailyUsageLogs />
         </div>
     );
 }

--- a/frontend/src/components/thread/tool-views/company-search-tool/CompanySearchToolView.tsx
+++ b/frontend/src/components/thread/tool-views/company-search-tool/CompanySearchToolView.tsx
@@ -41,7 +41,6 @@ export function CompanySearchToolView({
   const {
     query,
     total_results,
-    cost_deducted,
     results,
     actualIsSuccess,
     actualToolTimestamp,
@@ -81,11 +80,6 @@ export function CompanySearchToolView({
 
           {!isStreaming && (
             <div className="flex items-center gap-2">
-              {cost_deducted && (
-                <Badge variant="outline" className="text-xs font-normal text-orange-600 dark:text-orange-400">
-                  {cost_deducted}
-                </Badge>
-              )}
               <Badge
                 variant="secondary"
                 className={

--- a/frontend/src/components/thread/tool-views/company-search-tool/_utils.ts
+++ b/frontend/src/components/thread/tool-views/company-search-tool/_utils.ts
@@ -22,7 +22,6 @@ export interface CompanySearchResult {
 export interface CompanySearchData {
   query: string | null;
   total_results: number;
-  cost_deducted: string;
   enrichment_type: string;
   results: CompanySearchResult[];
   success?: boolean;
@@ -39,7 +38,6 @@ export function extractCompanySearchData(
 ): {
   query: string | null;
   total_results: number;
-  cost_deducted: string;
   enrichment_type: string;
   results: CompanySearchResult[];
   actualIsSuccess: boolean;
@@ -49,16 +47,15 @@ export function extractCompanySearchData(
   const args = toolCall.arguments || {};
   const query = args.query || null;
   const enrichment_type = args.enrichment_description || '';
-  
+
   let total_results = 0;
-  let cost_deducted = '$0.54';
   let results: CompanySearchResult[] = [];
 
   // Extract from toolResult output
   if (toolResult?.output) {
     const output = toolResult.output;
     let parsedOutput: any = {};
-    
+
     if (typeof output === 'string') {
       try {
         parsedOutput = JSON.parse(output);
@@ -70,7 +67,6 @@ export function extractCompanySearchData(
     }
 
     total_results = parsedOutput.total_results || 0;
-    cost_deducted = parsedOutput.cost_deducted || '$0.54';
     results = parsedOutput.results?.map((result: any) => ({
       rank: result.rank || 0,
       id: result.id || '',
@@ -96,7 +92,6 @@ export function extractCompanySearchData(
   return {
     query,
     total_results,
-    cost_deducted,
     enrichment_type,
     results,
     actualIsSuccess,

--- a/frontend/src/components/thread/tool-views/people-search-tool/PeopleSearchToolView.tsx
+++ b/frontend/src/components/thread/tool-views/people-search-tool/PeopleSearchToolView.tsx
@@ -43,7 +43,6 @@ export function PeopleSearchToolView({
   const {
     query,
     total_results,
-    cost_deducted,
     results,
     actualIsSuccess,
     actualToolTimestamp,
@@ -94,11 +93,6 @@ export function PeopleSearchToolView({
 
           {!isStreaming && (
             <div className="flex items-center gap-2">
-              {cost_deducted && (
-                <Badge variant="outline" className="text-xs font-normal text-orange-600 dark:text-orange-400">
-                  {cost_deducted}
-                </Badge>
-              )}
               <Badge
                 variant="secondary"
                 className={

--- a/frontend/src/components/thread/tool-views/people-search-tool/_utils.ts
+++ b/frontend/src/components/thread/tool-views/people-search-tool/_utils.ts
@@ -22,7 +22,6 @@ export interface PeopleSearchResult {
 export interface PeopleSearchData {
   query: string | null;
   total_results: number;
-  cost_deducted: string;
   enrichment_type: string;
   results: PeopleSearchResult[];
   success?: boolean;
@@ -39,7 +38,6 @@ export function extractPeopleSearchData(
 ): {
   query: string | null;
   total_results: number;
-  cost_deducted: string;
   enrichment_type: string;
   results: PeopleSearchResult[];
   actualIsSuccess: boolean;
@@ -49,16 +47,15 @@ export function extractPeopleSearchData(
   const args = toolCall.arguments || {};
   const query = args.query || null;
   const enrichment_type = args.enrichment_description || '';
-  
+
   let total_results = 0;
-  let cost_deducted = '$0.54';
   let results: PeopleSearchResult[] = [];
 
   // Extract from toolResult output
   if (toolResult?.output) {
     const output = toolResult.output;
     let parsedOutput: any = {};
-    
+
     if (typeof output === 'string') {
       try {
         parsedOutput = JSON.parse(output);
@@ -70,7 +67,6 @@ export function extractPeopleSearchData(
     }
 
     total_results = parsedOutput.total_results || 0;
-    cost_deducted = parsedOutput.cost_deducted || '$0.54';
     results = parsedOutput.results?.map((result: any) => ({
       rank: result.rank || 0,
       id: result.id || '',
@@ -96,7 +92,6 @@ export function extractPeopleSearchData(
   return {
     query,
     total_results,
-    cost_deducted,
     enrichment_type,
     results,
     actualIsSuccess,

--- a/frontend/src/hooks/billing/index.ts
+++ b/frontend/src/hooks/billing/index.ts
@@ -55,6 +55,13 @@ export { useBillingModal } from './use-billing-modal';
 // Credit & Thread Usage analytics
 export { useCreditUsage } from './use-credit-usage';
 export { useThreadUsage } from './use-thread-usage';
+export {
+  useCreditUsageDetail,
+  type CreditUsageDetailResponse,
+  type DayUsage,
+  type ThreadUsageDetail,
+  type UsageRecord,
+} from './use-credit-usage-detail';
 
 // =============================================================================
 // TIER CONFIGURATIONS - Static data, separate endpoint

--- a/frontend/src/hooks/billing/use-credit-usage-detail.ts
+++ b/frontend/src/hooks/billing/use-credit-usage-detail.ts
@@ -1,0 +1,82 @@
+import { useQuery } from '@tanstack/react-query';
+import { backendApi } from '@/lib/api-client';
+import { accountStateKeys } from './use-account-state';
+
+export interface UsageRecord {
+  time: string;
+  type_display: string;
+  prompt_tokens: number;
+  completion_tokens: number;
+  tool_cost: number;
+  total_cost: number;
+  credits: number;
+}
+
+export interface ThreadUsageDetail {
+  thread_id: string;
+  project_id: string | null;
+  project_name: string;
+  total_requests: number;
+  total_credits: number;
+  total_cost: number;
+  usage_records: UsageRecord[];
+}
+
+export interface DayUsage {
+  date: string;
+  date_display: string;
+  total_credits: number;
+  total_cost: number;
+  threads: ThreadUsageDetail[];
+}
+
+export interface CreditUsageDetailResponse {
+  daily_usage: DayUsage[];
+  summary: {
+    total_credits_used: number;
+    total_cost: number;
+    start_date: string;
+    end_date: string;
+  };
+}
+
+interface UseCreditUsageDetailParams {
+  days?: number;
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export function useCreditUsageDetail({
+  days,
+  startDate,
+  endDate,
+}: UseCreditUsageDetailParams = {}) {
+  return useQuery<CreditUsageDetailResponse>({
+    queryKey: [
+      ...accountStateKeys.all,
+      'credit-usage-detail',
+      days,
+      startDate?.toISOString(),
+      endDate?.toISOString(),
+    ],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (startDate && endDate) {
+        params.append('start_date', startDate.toISOString());
+        params.append('end_date', endDate.toISOString());
+      } else if (days) {
+        params.append('days', days.toString());
+      } else {
+        params.append('days', '30');
+      }
+      const response = await backendApi.get(
+        `/billing/credit-usage-detail?${params.toString()}`
+      );
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+      return response.data;
+    },
+    staleTime: 30000,
+  });
+}


### PR DESCRIPTION
Changes:
- Added a Tool Billing service which does dedicated credit deduction on the basis of Enterprise mode and SaaS mode.
- DB migration
  - Added tables for `tool_costs`, `enterprise_global_limits`
  - Added required columns to `enterprise_usage`
- In ResponseProcessor:
  - Added check before tool usage to check for required credits
  - Added deduction after successful took usage
- Queries the tool costs in `get_openapi_schemas()` and injects them into the tool descriptions.
  - This gives agents context of the cost of the tool
- Removed credit deduction for the CompanySearchTool and PeopleSearchTool, and updated prompt for the same
- Credit usage details:
  - UI: updated the credit usage view for each project - prompt/tool level details
  - API: new endpoint: `/api/billing/credit-usage-details` to get tool usage data grouped by "creation date" and "project"


**NOTE**: We can later adjust the default tool function cost values in a future migration if required. 