### PR TITLE
Last LLM call check

### DIFF
--- a/backend/core/agentpress/thread_manager.py
+++ b/backend/core/agentpress/thread_manager.py
@@ -4,7 +4,7 @@ Simplified conversation thread management system for AgentPress.
 
 import asyncio
 import json
-from typing import List, Dict, Any, Optional, Type, Union, AsyncGenerator, Literal, cast
+from typing import List, Dict, Any, Optional, Type, Union, AsyncGenerator, Literal, cast, Tuple
 from core.services.llm import make_llm_api_call, LLMError
 from core.agentpress.prompt_caching import apply_anthropic_caching_strategy, validate_cache_blocks
 from core.agentpress.tool import Tool
@@ -19,6 +19,10 @@ from core.services.langfuse import langfuse
 from datetime import datetime, timezone
 from core.billing.credits.integration import billing_integration
 from core.billing.tool_billing import tool_billing_service
+from core.billing.shared.config import (
+    CREDIT_CHECK_ESTIMATED_PROMPT_TOKENS,
+    CREDIT_CHECK_ESTIMATED_OUTPUT_TOKENS,
+)
 from litellm.utils import token_counter
 import litellm
 
@@ -713,7 +717,15 @@ class ThreadManager:
                 if account_id:
                     try:
                         from core.billing.credits.integration import billing_integration
-                        can_run, message, _ = await billing_integration.check_and_reserve_credits(account_id)
+                        estimated_prompt, estimated_completion = self._estimate_max_tokens_for_iteration(
+                            llm_model, llm_max_tokens
+                        )
+                        can_run, message, _ = await billing_integration.check_and_reserve_credits(
+                            account_id,
+                            model_name=llm_model,
+                            estimated_prompt_tokens=estimated_prompt,
+                            estimated_completion_tokens=estimated_completion,
+                        )
                         if not can_run:
                             logger.warning(f"Stopping auto-continue - insufficient credits: {message}")
                             yield {
@@ -810,6 +822,34 @@ class ThreadManager:
                 "type": "content",
                 "content": f"\n[Agent reached maximum auto-continue limit of {native_max_auto_continues}]"
             }
+
+    def _estimate_max_tokens_for_iteration(
+        self, llm_model: str, llm_max_tokens: Optional[int]
+    ) -> Tuple[int, int]:
+        """
+        Conservative estimate of max tokens for one LLM call (prompt + completion).
+        Used for credit capacity checks before each auto-continue iteration.
+        Note: llm_max_tokens is typically None (AgentRunner lets providers use defaults).
+        """
+        try:
+            from core.ai_models import model_manager
+            context_window = model_manager.get_context_window(llm_model)
+            model = model_manager.get_model(model_manager.resolve_model_id(llm_model))
+
+            # llm_max_tokens is usually None; only use if valid positive int
+            if llm_max_tokens is not None and llm_max_tokens > 0:
+                max_output = min(llm_max_tokens, context_window)  # cap to context
+            else:
+                max_output = (
+                    (model.max_output_tokens if model and model.max_output_tokens else None)
+                    or min(CREDIT_CHECK_ESTIMATED_OUTPUT_TOKENS, context_window)
+                )
+
+            estimated_prompt = min(context_window, CREDIT_CHECK_ESTIMATED_PROMPT_TOKENS)
+            estimated_completion = max_output
+            return estimated_prompt, estimated_completion
+        except Exception:
+            return CREDIT_CHECK_ESTIMATED_PROMPT_TOKENS, CREDIT_CHECK_ESTIMATED_OUTPUT_TOKENS
 
     def _check_auto_continue_trigger(
         self, chunk: Dict[str, Any], auto_continue_state: Dict[str, Any], 

--- a/backend/core/billing/credits/integration.py
+++ b/backend/core/billing/credits/integration.py
@@ -11,34 +11,72 @@ from ..shared.cache_utils import invalidate_account_state_cache
 
 class BillingIntegration:
     @staticmethod
-    async def check_and_reserve_credits(account_id: str, estimated_tokens: int = 10000) -> Tuple[bool, str, Optional[str]]:
+    async def check_and_reserve_credits(
+        account_id: str,
+        estimated_tokens: Optional[int] = None,
+        model_name: Optional[str] = None,
+        estimated_prompt_tokens: Optional[int] = None,
+        estimated_completion_tokens: Optional[int] = None,
+    ) -> Tuple[bool, str, Optional[str]]:
+        """
+        Check if account has capacity to run (and optionally to cover estimated token cost).
+        When model_name + token estimates are provided, verifies balance >= estimated cost.
+        """
         if config.ENV_MODE == EnvMode.LOCAL:
             return True, "Local mode", None
-        
+
+        estimated_cost: Optional[Decimal] = None
+        if model_name and (estimated_tokens or estimated_prompt_tokens is not None or estimated_completion_tokens is not None):
+            prompt_tokens: int
+            completion_tokens: int
+            if estimated_prompt_tokens is not None and estimated_completion_tokens is not None:
+                prompt_tokens = estimated_prompt_tokens
+                completion_tokens = estimated_completion_tokens
+            elif estimated_tokens is not None and estimated_tokens > 0:
+                prompt_tokens = int(estimated_tokens * 0.8)
+                completion_tokens = estimated_tokens - prompt_tokens
+            else:
+                prompt_tokens = 0
+                completion_tokens = 0
+            if prompt_tokens > 0 or completion_tokens > 0:
+                try:
+                    estimated_cost = calculate_token_cost(prompt_tokens, completion_tokens, model_name)
+                except Exception as e:
+                    logger.warning(f"[BILLING] Failed to estimate cost, falling back to balance check: {e}")
+
         # ===== ENTERPRISE MODE FORK =====
         if config.ENTERPRISE_MODE:
-            # Use enterprise billing - check shared pool and user limits
             from core.billing.enterprise.service import enterprise_billing_service
-            return await enterprise_billing_service.check_billing_status(account_id)
+            cost_for_check = float(estimated_cost) if estimated_cost is not None and estimated_cost > 0 else 0.01
+            logger.debug(f"[BILLING] Checking enterprise billing status for {account_id} with estimated cost: ${cost_for_check:.6f}")
+            return await enterprise_billing_service.check_billing_status(
+                account_id, estimated_cost=Decimal(str(cost_for_check))
+            )
         # ================================
-        
+
         # Standard SaaS mode - check and refresh daily credits
         try:
             from core.credits import credit_service
             await credit_service.check_and_refresh_daily_credits(account_id)
         except Exception as e:
             logger.warning(f"[DAILY_CREDITS] Failed to check/refresh daily credits for {account_id}: {e}")
-        
+
         balance_info = await credit_manager.get_balance(account_id)
-        
+
         if isinstance(balance_info, dict):
             balance = Decimal(str(balance_info.get('total', 0)))
         else:
             balance = Decimal(str(balance_info or 0))
-        
+
         if balance < 0:
             return False, f"Insufficient credits. Your balance is {int(balance * 100)} credits. Please add credits to continue.", None
-        
+
+        if estimated_cost is not None and estimated_cost > 0 and balance < estimated_cost:
+            return False, (
+                f"Insufficient credits for estimated usage (${float(estimated_cost):.4f}). "
+                f"Your balance is ${float(balance):.2f}. Please add credits to continue."
+            ), None
+
         return True, f"Credits available: {int(balance * 100)} credits", None
     
     @staticmethod

--- a/backend/core/billing/shared/config.py
+++ b/backend/core/billing/shared/config.py
@@ -14,6 +14,10 @@ TOKEN_PRICE_MULTIPLIER = Decimal('1.2')
 MINIMUM_CREDIT_FOR_RUN = Decimal('0.01')
 DEFAULT_TOKEN_COST = Decimal('0.000002')
 
+# Credit capacity check: estimated tokens per LLM iteration (used before auto-continue)
+CREDIT_CHECK_ESTIMATED_PROMPT_TOKENS = 12_000
+CREDIT_CHECK_ESTIMATED_OUTPUT_TOKENS = 1_000
+
 CREDITS_PER_DOLLAR = 100
 
 FREE_TIER_INITIAL_CREDITS = Decimal('0.00')


### PR DESCRIPTION
## Previous method:

Hardcoded a dollar amount to be checked: `$0.01`
```python
can_make_llm_call = current_balance > 0.01
```


## This method:

Hardcoding the token amount (prompt tokens + output tokens) to be checked.

```python
CREDIT_CHECK_ESTIMATED_PROMPT_TOKENS = 12_000 # current static value
CREDIT_CHECK_ESTIMATED_OUTPUT_TOKENS = 1_000 # current static value

dollar_threshold = calculate_token_cost(CREDIT_CHECK_ESTIMATED_PROMPT_TOKENS, CREDIT_CHECK_ESTIMATED_OUTPUT_TOKENS, model="whichever model is chosen")

can_make_llm_call = current_balance > dollar_threshold
```

## How it differs:

> Different dollar thresholds based on the model (OMNI Basic / OMNI Power)

Calculates the price threshold using the formula: `(prompt/1e6 × input_price + completion/1e6 × output_price) × 1.2`

Is relatively more stricter for more expensive models.

## Current estimates
Model | Calculation | Cost threshold
-- | -- | --
Basic | (0.012 × 1 + 0.001 × 5) × 1.2 | ~$0.020
Power | (0.012 × 3 + 0.001 × 15) × 1.2 | ~$0.061

