### PR TITLE
feat: Implement low credit alert email functionality and MailTrap configuration - corrected

### DIFF
--- a/backend/core/admin/notification_admin_api.py
+++ b/backend/core/admin/notification_admin_api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from typing import Dict, Optional, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from core.utils.logger import logger
 from core.auth import require_admin
 from core.notifications.notification_service import notification_service
@@ -14,6 +14,11 @@ class TriggerWorkflowRequest(BaseModel):
     subscriber_id: Optional[str] = None
     subscriber_email: Optional[str] = None
     broadcast: bool = False
+
+
+class TestLowCreditAlertRequest(BaseModel):
+    account_id: str = Field(..., description="User account ID to send the test alert to")
+    balance: float = Field(0.50, description="Simulated balance to show in the email (default $0.50)")
 
 
 @router.get("/workflows")
@@ -97,4 +102,37 @@ async def trigger_workflow_admin(
         raise
     except Exception as e:
         logger.error(f"[ADMIN] Error triggering workflow: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/test-low-credit-alert")
+async def test_low_credit_alert(
+    request: TestLowCreditAlertRequest,
+    admin: dict = Depends(require_admin)
+):
+    """Send a test low-credit alert email to a specific user. Bypasses the 24-hour deduplication guard."""
+    try:
+        logger.info(f"[ADMIN] Sending test low credit alert to account {request.account_id} (balance: ${request.balance:.2f})")
+
+        # Bypass the deduplication cache by calling the notification service directly
+        result = await notification_service.send_low_credit_alert_email(
+            account_id=request.account_id,
+            balance=request.balance
+        )
+
+        if not result.get("success"):
+            raise HTTPException(
+                status_code=500,
+                detail=result.get("error", "Failed to send low credit alert email")
+            )
+
+        return {
+            "success": True,
+            "message": f"Low credit alert email sent to account {request.account_id} (simulated balance: ${request.balance:.2f})"
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"[ADMIN] Error sending test low credit alert: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/core/credits.py
+++ b/backend/core/credits.py
@@ -188,6 +188,41 @@ class CreditService:
         
         return balance
     
+    LOW_CREDIT_THRESHOLD = Decimal('1.00')
+
+    async def _maybe_send_low_credit_alert(self, user_id: str, new_balance: Decimal) -> None:
+        """Send a low-credit alert email when balance drops below the threshold.
+
+        A Redis cache key with a 24-hour TTL prevents the user from receiving
+        more than one alert per day. All exceptions are caught so a cache or
+        email failure never surfaces as an unhandled task exception.
+        """
+        try:
+            if new_balance >= self.LOW_CREDIT_THRESHOLD:
+                return
+
+            alert_cache_key = f"low_credit_alert_sent:{user_id}"
+            if self.cache:
+                try:
+                    already_sent = await self.cache.get(alert_cache_key)
+                    if already_sent:
+                        return
+                    # Mark as sent for 24 hours before firing so parallel calls don't race
+                    await self.cache.set(alert_cache_key, "1", ttl=86400)
+                except Exception as cache_err:
+                    logger.warning(
+                        f"[LOW_CREDIT_ALERT] Cache unavailable for user {user_id}, "
+                        f"proceeding without deduplication guard: {cache_err}"
+                    )
+
+            from core.notifications.notification_service import notification_service
+            await notification_service.send_low_credit_alert_email(
+                account_id=user_id,
+                balance=float(new_balance)
+            )
+        except Exception as e:
+            logger.error(f"[LOW_CREDIT_ALERT] Failed to send alert for user {user_id}: {e}")
+
     async def deduct_credits(self, user_id: str, amount: Decimal, description: str = None, reference_id: str = None, reference_type: str = None) -> Dict:
         try:
             client = await self._get_client()
@@ -209,6 +244,7 @@ class CreditService:
                 transaction_id = row.get('transaction_id')
                 
                 if success:
+                    asyncio.create_task(self._maybe_send_low_credit_alert(user_id, new_balance))
                     return {
                         'success': True,
                         'new_balance': new_balance,

--- a/backend/core/notifications/notification_service.py
+++ b/backend/core/notifications/notification_service.py
@@ -433,6 +433,40 @@ class NotificationService:
         
         return json.loads(template_str)
     
+    async def send_low_credit_alert_email(
+        self,
+        account_id: str,
+        balance: float
+    ) -> Dict[str, Any]:
+        try:
+            account_info = await self._get_account_info(account_id)
+
+            if not account_info or not account_info.get("email"):
+                logger.warning(f"[LOW_CREDIT_ALERT] No email found for user {account_id}")
+                return {"success": False, "error": "No email found for user"}
+
+            email = account_info.get("email")
+            name = account_info.get("name")
+
+            logger.info(f"[LOW_CREDIT_ALERT] Sending low credit alert to {email} (balance: ${balance:.2f})")
+
+            success = email_service.send_low_credit_alert_email(
+                user_email=email,
+                user_name=name,
+                balance=balance
+            )
+
+            if success:
+                logger.info(f"[LOW_CREDIT_ALERT] Alert sent to {email} for account {account_id}")
+                return {"success": True}
+            else:
+                logger.error(f"[LOW_CREDIT_ALERT] Failed to send alert to {email}")
+                return {"success": False, "error": "Failed to send email"}
+
+        except Exception as e:
+            logger.error(f"[LOW_CREDIT_ALERT] Error sending alert for account {account_id}: {str(e)}")
+            return {"success": False, "error": str(e)}
+
     async def send_welcome_email(self, account_id: str) -> Dict[str, Any]:
         try:
             logger.info(f"[WELCOME_EMAIL] ENV_MODE={config.ENV_MODE.value if config.ENV_MODE else 'None'}, Novu enabled={self.novu.enabled}, API key configured={bool(self.novu.api_key)}")

--- a/backend/core/services/email.py
+++ b/backend/core/services/email.py
@@ -6,12 +6,17 @@ from core.utils.config import config
 
 logger = logging.getLogger(__name__)
 
+
 class EmailService:
     def __init__(self):
-        self.api_token = os.getenv('MAILTRAP_API_TOKEN')
-        self.sender_email = os.getenv('MAILTRAP_SENDER_EMAIL', 'hey@omnisciencelabs.com')
-        self.sender_name = os.getenv('MAILTRAP_SENDER_NAME', 'Omni Team')
-        self.hello_email = os.getenv('MAILTRAP_SENDER_EMAIL', 'hello@omnisciencelabs.com')
+        self.api_token = os.getenv("MAILTRAP_API_TOKEN")
+        self.sender_email = os.getenv(
+            "MAILTRAP_SENDER_EMAIL", "hey@omnisciencelabs.com"
+        )
+        self.sender_name = os.getenv("MAILTRAP_SENDER_NAME", "Omni Team")
+        self.hello_email = os.getenv(
+            "MAILTRAP_SENDER_EMAIL", "hello@omnisciencelabs.com"
+        )
 
         if not self.api_token:
             logger.warning("MAILTRAP_API_TOKEN not found in environment variables")
@@ -19,13 +24,15 @@ class EmailService:
         else:
             self.client = mt.MailtrapClient(token=self.api_token)
 
-    def send_welcome_email(self, user_email: str, user_name: Optional[str] = None) -> bool:
+    def send_welcome_email(
+        self, user_email: str, user_name: Optional[str] = None
+    ) -> bool:
         if not self.client:
             logger.error("Cannot send email: MAILTRAP_API_TOKEN not configured")
             return False
 
         if not user_name:
-            user_name = user_email.split('@')[0].title()
+            user_name = user_email.split("@")[0].title()
 
         subject = "🎉 Welcome to Omni — Let's Get Started"
         html_content = self._get_welcome_email_template(user_name)
@@ -36,7 +43,7 @@ class EmailService:
             to_name=user_name,
             subject=subject,
             html_content=html_content,
-            text_content=text_content
+            text_content=text_content,
         )
 
     def send_referral_email(
@@ -44,46 +51,62 @@ class EmailService:
         recipient_email: str,
         recipient_name: str,
         sender_name: str,
-        referral_url: str
+        referral_url: str,
     ) -> bool:
         if not self.client:
             logger.error("Cannot send email: MAILTRAP_API_TOKEN not configured")
             return False
 
         subject = "🎉 You're invited!"
-        html_content = self._get_referral_email_template(recipient_name, sender_name, referral_url)
-        text_content = self._get_referral_email_text(recipient_name, sender_name, referral_url)
+        html_content = self._get_referral_email_template(
+            recipient_name, sender_name, referral_url
+        )
+        text_content = self._get_referral_email_text(
+            recipient_name, sender_name, referral_url
+        )
 
         try:
             sender_email_to_use = self.hello_email
 
-            logger.info(f"Attempting to send referral email from {sender_email_to_use} to {recipient_email}")
+            logger.info(
+                f"Attempting to send referral email from {sender_email_to_use} to {recipient_email}"
+            )
 
             mail = mt.Mail(
-                sender=mt.Address(email=sender_email_to_use, name='Omni'),
+                sender=mt.Address(email=sender_email_to_use, name="Omni"),
                 to=[mt.Address(email=recipient_email, name=recipient_name)],
                 subject=subject,
                 text=text_content,
                 html=html_content,
-                category="referral"
+                category="referral",
             )
 
             response = self.client.send(mail)
 
-            logger.info(f"Referral email sent to {recipient_email} from {sender_name}. Response: {response}")
+            logger.info(
+                f"Referral email sent to {recipient_email} from {sender_name}. Response: {response}"
+            )
             return True
 
         except Exception as e:
             error_type = type(e).__name__
             error_details = str(e)
-            logger.error(f"Error sending referral email to {recipient_email}: {error_details}")
+            logger.error(
+                f"Error sending referral email to {recipient_email}: {error_details}"
+            )
             logger.error(f"Error type: {error_type}")
-            logger.error(f"Mailtrap API Token present: {bool(self.api_token)}, Token prefix: {self.api_token[:8] if self.api_token else 'None'}...")
+            logger.error(
+                f"Mailtrap API Token present: {bool(self.api_token)}, Token prefix: {self.api_token[:8] if self.api_token else 'None'}..."
+            )
             logger.error(f"Sender email: {sender_email_to_use}")
 
-            if hasattr(e, 'response'):
-                logger.error(f"Response status: {e.response.status_code if hasattr(e.response, 'status_code') else 'unknown'}")
-                logger.error(f"Response body: {e.response.text if hasattr(e.response, 'text') else 'unknown'}")
+            if hasattr(e, "response"):
+                logger.error(
+                    f"Response status: {e.response.status_code if hasattr(e.response, 'status_code') else 'unknown'}"
+                )
+                logger.error(
+                    f"Response body: {e.response.text if hasattr(e.response, 'text') else 'unknown'}"
+                )
 
             return False
 
@@ -93,7 +116,7 @@ class EmailService:
         to_name: str,
         subject: str,
         html_content: str,
-        text_content: str
+        text_content: str,
     ) -> bool:
         try:
             mail = mt.Mail(
@@ -102,7 +125,7 @@ class EmailService:
                 subject=subject,
                 text=text_content,
                 html=html_content,
-                category="welcome"
+                category="welcome",
             )
 
             response = self.client.send(mail)
@@ -214,7 +237,9 @@ Thanks again, and welcome to the Omni community!
 © 2025 Omniscience Labs. All rights reserved.
 You received this email because you signed up for an Omni account."""
 
-    def _get_referral_email_template(self, recipient_name: str, sender_name: str, referral_url: str) -> str:
+    def _get_referral_email_template(
+        self, recipient_name: str, sender_name: str, referral_url: str
+    ) -> str:
         content = f"""<table cellpadding="0" cellspacing="0" border="0" style="padding:30px 15px; font-family:Inter, Arial, sans-serif; color:#000000;">
   <tr>
     <td>
@@ -279,7 +304,9 @@ You received this email because you signed up for an Omni account."""
 </body>
 </html>"""
 
-    def _get_referral_email_text(self, recipient_name: str, sender_name: str, referral_url: str) -> str:
+    def _get_referral_email_text(
+        self, recipient_name: str, sender_name: str, referral_url: str
+    ) -> str:
         return f"""Hi {recipient_name},
 
 {sender_name} has invited you to join Omni using a personal referral code.
@@ -295,17 +322,14 @@ Claim your invite: {referral_url}
 © Omniscience Labs. All rights reserved."""
 
     def send_low_credit_alert_email(
-        self,
-        user_email: str,
-        user_name: Optional[str] = None,
-        balance: float = 0.0
+        self, user_email: str, user_name: Optional[str] = None, balance: float = 0.0
     ) -> bool:
         if not self.client:
             logger.error("Cannot send email: MAILTRAP_API_TOKEN not configured")
             return False
 
         if not user_name:
-            user_name = user_email.split('@')[0].title()
+            user_name = user_email.split("@")[0].title()
 
         subject = "⚠️ Your Omni credits are running low"
         html_content = self._get_low_credit_alert_template(user_name, balance)
@@ -318,15 +342,19 @@ Claim your invite: {referral_url}
                 subject=subject,
                 text=text_content,
                 html=html_content,
-                category="low_credit_alert"
+                category="low_credit_alert",
             )
 
             response = self.client.send(mail)
-            logger.info(f"Low credit alert email sent to {user_email} (balance: ${balance:.2f}). Response: {response}")
+            logger.info(
+                f"Low credit alert email sent to {user_email} (balance: ${balance:.2f}). Response: {response}"
+            )
             return True
 
         except Exception as e:
-            logger.error(f"Error sending low credit alert email to {user_email}: {str(e)}")
+            logger.error(
+                f"Error sending low credit alert email to {user_email}: {str(e)}"
+            )
             return False
 
     def _get_low_credit_alert_template(self, user_name: str, balance: float) -> str:
@@ -351,14 +379,15 @@ Claim your invite: {referral_url}
             Hi <strong>{user_name}</strong>,
           </p>
           <p style="margin:0 0 20px 0; font-size:15px; line-height:1.6; color:#374151;">
-            Your Omni credit balance has dropped to <strong style="color:#DC2626;">${balance:.2f}</strong>.
-            To avoid any interruption to your agents and workflows, please top up your credits.
+            We wanted to give you a quick update that your Omni credit balance has dropped to <strong style="color:#DC2626;">${balance:.2f}</strong>.
+          </p>
+          <p style="margin:0 0 20px 0; font-size:15px; line-height:1.6; color:#374151;">
+            To keep your workflows running smoothly and ensure no interruptions to your active agents, we kindly request that you add some more credits to your account.
           </p>
           <table cellpadding="0" cellspacing="0" border="0" style="background:#fef3c7; border:1px solid #fcd34d; border-radius:12px; padding:16px; margin:0 0 24px 0; width:100%;">
             <tr>
               <td style="font-size:14px; line-height:1.6; color:#92400e;">
-                <strong>Current balance:</strong> ${balance:.2f}<br/>
-                <strong>Minimum to run agents:</strong> $0.01
+                <strong>Current balance:</strong> ${balance:.2f}
               </td>
             </tr>
           </table>
@@ -366,11 +395,15 @@ Claim your invite: {referral_url}
             <tr>
               <td>
                 <a href="https://becomeomni.com/" style="background:#000000; color:#ffffff; padding:12px 28px; text-decoration:none; font-size:15px; font-weight:600; border-radius:12px; display:inline-block;">
-                  Top Up Credits →
+                  Add Credits
                 </a>
               </td>
             </tr>
           </table>
+          <p style="margin:0 0 20px 0; font-size:15px; line-height:1.6; color:#374151;">
+            Best,<br/>
+            <strong>The Omni Team</strong>
+          </p>
           <p style="margin:0; font-size:13px; line-height:1.6; color:#9ca3af;">
             You can also set up auto top-up in your billing settings so this never happens again.
           </p>
@@ -392,12 +425,14 @@ Claim your invite: {referral_url}
 
 Your Omni credit balance has dropped to ${balance:.2f}.
 
-To avoid any interruption to your agents and workflows, please top up your credits.
+To keep your workflows running smoothly and ensure no interruptions to your active agents, we kindly request that you add some more credits to your account.
 
 Current balance: ${balance:.2f}
-Minimum to run agents: $0.01
 
-Top up your credits here: https://becomeomni.com/
+Add credits here: https://becomeomni.com/
+
+Best,
+The Omni Team
 
 You can also set up auto top-up in your billing settings so this never happens again.
 

--- a/backend/core/services/email.py
+++ b/backend/core/services/email.py
@@ -9,28 +9,28 @@ logger = logging.getLogger(__name__)
 class EmailService:
     def __init__(self):
         self.api_token = os.getenv('MAILTRAP_API_TOKEN')
-        self.sender_email = os.getenv('MAILTRAP_SENDER_EMAIL', 'hey@kortix.com')
-        self.sender_name = os.getenv('MAILTRAP_SENDER_NAME', 'Kortix Team')
-        self.hello_email = 'hello@kortix.com'
-        
+        self.sender_email = os.getenv('MAILTRAP_SENDER_EMAIL', 'hey@omnisciencelabs.com')
+        self.sender_name = os.getenv('MAILTRAP_SENDER_NAME', 'Omni Team')
+        self.hello_email = os.getenv('MAILTRAP_SENDER_EMAIL', 'hello@omnisciencelabs.com')
+
         if not self.api_token:
             logger.warning("MAILTRAP_API_TOKEN not found in environment variables")
             self.client = None
         else:
             self.client = mt.MailtrapClient(token=self.api_token)
-    
+
     def send_welcome_email(self, user_email: str, user_name: Optional[str] = None) -> bool:
         if not self.client:
             logger.error("Cannot send email: MAILTRAP_API_TOKEN not configured")
             return False
-    
+
         if not user_name:
             user_name = user_email.split('@')[0].title()
-        
-        subject = "🎉 Welcome to Kortix — Let's Get Started "
+
+        subject = "🎉 Welcome to Omni — Let's Get Started"
         html_content = self._get_welcome_email_template(user_name)
         text_content = self._get_welcome_email_text(user_name)
-        
+
         return self._send_email(
             to_email=user_email,
             to_name=user_name,
@@ -38,41 +38,41 @@ class EmailService:
             html_content=html_content,
             text_content=text_content
         )
-    
+
     def send_referral_email(
-        self, 
-        recipient_email: str, 
+        self,
+        recipient_email: str,
         recipient_name: str,
-        sender_name: str, 
+        sender_name: str,
         referral_url: str
     ) -> bool:
         if not self.client:
             logger.error("Cannot send email: MAILTRAP_API_TOKEN not configured")
             return False
-        
-        subject = f"🎉 You're invited!"
+
+        subject = "🎉 You're invited!"
         html_content = self._get_referral_email_template(recipient_name, sender_name, referral_url)
         text_content = self._get_referral_email_text(recipient_name, sender_name, referral_url)
-        
+
         try:
             sender_email_to_use = self.hello_email
-            
+
             logger.info(f"Attempting to send referral email from {sender_email_to_use} to {recipient_email}")
-            
+
             mail = mt.Mail(
-                sender=mt.Address(email=sender_email_to_use, name='Kortix'),
+                sender=mt.Address(email=sender_email_to_use, name='Omni'),
                 to=[mt.Address(email=recipient_email, name=recipient_name)],
                 subject=subject,
                 text=text_content,
                 html=html_content,
                 category="referral"
             )
-            
+
             response = self.client.send(mail)
-            
+
             logger.info(f"Referral email sent to {recipient_email} from {sender_name}. Response: {response}")
             return True
-                
+
         except Exception as e:
             error_type = type(e).__name__
             error_details = str(e)
@@ -80,19 +80,19 @@ class EmailService:
             logger.error(f"Error type: {error_type}")
             logger.error(f"Mailtrap API Token present: {bool(self.api_token)}, Token prefix: {self.api_token[:8] if self.api_token else 'None'}...")
             logger.error(f"Sender email: {sender_email_to_use}")
-            
+
             if hasattr(e, 'response'):
                 logger.error(f"Response status: {e.response.status_code if hasattr(e.response, 'status_code') else 'unknown'}")
                 logger.error(f"Response body: {e.response.text if hasattr(e.response, 'text') else 'unknown'}")
-            
+
             return False
-    
+
     def _send_email(
-        self, 
-        to_email: str, 
-        to_name: str, 
-        subject: str, 
-        html_content: str, 
+        self,
+        to_email: str,
+        to_name: str,
+        subject: str,
+        html_content: str,
         text_content: str
     ) -> bool:
         try:
@@ -104,23 +104,23 @@ class EmailService:
                 html=html_content,
                 category="welcome"
             )
-            
+
             response = self.client.send(mail)
-            
+
             logger.debug(f"Welcome email sent to {to_email}. Response: {response}")
             return True
-                
+
         except Exception as e:
             logger.error(f"Error sending email to {to_email}: {str(e)}")
             return False
-    
+
     def _get_welcome_email_template(self, user_name: str) -> str:
         return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Welcome to Kortix</title>
+  <title>Welcome to Omni</title>
   <style>
     body {{
       font-family: Arial, sans-serif;
@@ -186,44 +186,34 @@ class EmailService:
 <body>
   <div class="container">
     <div class="logo-container">
-      <img src="https://heprlhlltebrxydgtsjs.supabase.co/storage/v1/object/public/image-uploads/loaded_images/Profile%20Picture%20Black.png" alt="Kortix Logo" class="logo">
+      <img src="https://becomeomni.com/favicon.ico" alt="Omni Logo" class="logo">
     </div>
 
     <p>Hi {user_name},</p>
 
-    <p><em><strong>Welcome to <a href="https://www.kortix.com/">Kortix.com</a> — we're excited to have you on board!</strong></em></p>
+    <p><em><strong>Welcome to <a href="https://becomeomni.com/">Omni</a> — we're excited to have you on board!</strong></em></p>
 
-    <p>To get started, we'd like to get to know you better: fill out this short <a href="https://docs.google.com/forms/d/e/1FAIpQLSef1EHuqmIh_iQz-kwhjnzSC3Ml-V_5wIySDpMoMU9W_j24JQ/viewform">form</a>!</p>
 
-    <p>To celebrate your arrival, here's a <strong>15% discount</strong> for your first month:</p>
-    <p>🎁 Use code <strong>WELCOME15</strong> at checkout.</p>
+    <p>Let us know if you need help getting started or have questions — we're always here.
 
-    <p>Let us know if you need help getting started or have questions — we're always here, and join our <a href="https://discord.com/invite/RvFhXUdZ9H">Discord community</a>.</p>
-
-    <p>Thanks again, and welcome to the Kortix community!</p>
+    <p>Thanks again, and welcome to the Omni community!</p>
   </div>
 </body>
 </html>"""
-    
+
     def _get_welcome_email_text(self, user_name: str) -> str:
         return f"""Hi {user_name},
 
-Welcome to https://www.kortix.com/ — we're excited to have you on board!
+Welcome to https://becomeomni.com/ — we're excited to have you on board!
 
-To get started, we'd like to get to know you better: fill out this short form!
-https://docs.google.com/forms/d/e/1FAIpQLSef1EHuqmIh_iQz-kwhjnzSC3Ml-V_5wIySDpMoMU9W_j24JQ/viewform
+Let us know if you need help getting started or have questions — we're always here.
 
-To celebrate your arrival, here's a 15% discount for your first month:
-🎁 Use code WELCOME15 at checkout.
-
-Let us know if you need help getting started or have questions — we're always here, and join our Discord community: https://discord.com/invite/RvFhXUdZ9H
-
-Thanks again, and welcome to the Kortix community!
+Thanks again, and welcome to the Omni community!
 
 ---
-© 2025 Kortix. All rights reserved.
-You received this email because you signed up for a Kortix account."""
-    
+© 2025 Omniscience Labs. All rights reserved.
+You received this email because you signed up for an Omni account."""
+
     def _get_referral_email_template(self, recipient_name: str, sender_name: str, referral_url: str) -> str:
         content = f"""<table cellpadding="0" cellspacing="0" border="0" style="padding:30px 15px; font-family:Inter, Arial, sans-serif; color:#000000;">
   <tr>
@@ -232,7 +222,7 @@ You received this email because you signed up for a Kortix account."""
         Hi <strong>{recipient_name}</strong>,  👋
       </p>
       <p style="margin:0 0 20px 0; font-size:15px; line-height:1.6;">
-        <strong>{sender_name}</strong> has invited you to join Kortix using a personal referral code.
+        <strong>{sender_name}</strong> has invited you to join Omni using a personal referral code.
         When you sign up using this link, both you and {sender_name} will receive 100 in non-expiring credits 🎁
       </p>
       <p style="margin:0 0 10px 0; font-weight:600;">
@@ -260,27 +250,27 @@ You received this email because you signed up for a Kortix account."""
     </td>
   </tr>
 </table>"""
-        
+
         return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Kortix</title>
+  <title>Omni</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #fafafa; color: #1a1a1a;">
   <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 520px; margin: 0 auto; padding: 40px 20px;">
     <tr>
       <td>
         <div style="text-align: center; margin-bottom: 40px;">
-          <img src="https://kortix.com/Logomark.svg" alt="Kortix" style="height: 24px; width: auto; display: inline-block;" />
+          <img src="https://becomeomni.com/favicon.ico" alt="Omni" style="height: 24px; width: auto; display: inline-block;" />
         </div>
         <div style="background-color: #ffffff; border-radius: 16px; padding: 40px 32px;">
           {content}
         </div>
         <div style="text-align: center; margin-top: 32px;">
           <p style="font-size: 12px; color: #999; margin: 0;">
-            &copy; Kortix AI Corp. All rights reserved.
+            &copy; Omniscience Labs. All rights reserved.
           </p>
         </div>
       </td>
@@ -288,11 +278,11 @@ You received this email because you signed up for a Kortix account."""
   </table>
 </body>
 </html>"""
-    
+
     def _get_referral_email_text(self, recipient_name: str, sender_name: str, referral_url: str) -> str:
         return f"""Hi {recipient_name},
 
-{sender_name} has invited you to join Kortix using a personal referral code.
+{sender_name} has invited you to join Omni using a personal referral code.
 
 When you sign up using this link, both you and {sender_name} will receive 100 in non-expiring credits 🎁
 
@@ -302,6 +292,118 @@ What You Both Get:
 Claim your invite: {referral_url}
 
 ---
-© Kortix AI Corp. All rights reserved."""
+© Omniscience Labs. All rights reserved."""
 
-email_service = EmailService() 
+    def send_low_credit_alert_email(
+        self,
+        user_email: str,
+        user_name: Optional[str] = None,
+        balance: float = 0.0
+    ) -> bool:
+        if not self.client:
+            logger.error("Cannot send email: MAILTRAP_API_TOKEN not configured")
+            return False
+
+        if not user_name:
+            user_name = user_email.split('@')[0].title()
+
+        subject = "⚠️ Your Omni credits are running low"
+        html_content = self._get_low_credit_alert_template(user_name, balance)
+        text_content = self._get_low_credit_alert_text(user_name, balance)
+
+        try:
+            mail = mt.Mail(
+                sender=mt.Address(email=self.sender_email, name=self.sender_name),
+                to=[mt.Address(email=user_email, name=user_name)],
+                subject=subject,
+                text=text_content,
+                html=html_content,
+                category="low_credit_alert"
+            )
+
+            response = self.client.send(mail)
+            logger.info(f"Low credit alert email sent to {user_email} (balance: ${balance:.2f}). Response: {response}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error sending low credit alert email to {user_email}: {str(e)}")
+            return False
+
+    def _get_low_credit_alert_template(self, user_name: str, balance: float) -> str:
+        return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your credits are running low</title>
+</head>
+<body style="margin:0; padding:0; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color:#fafafa; color:#1a1a1a;">
+  <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:520px; margin:0 auto; padding:40px 20px;">
+    <tr>
+      <td>
+        <div style="text-align:center; margin-bottom:32px;">
+          <img src="https://becomeomni.com/favicon.ico" alt="Omni" style="height:32px; width:auto; display:inline-block;" />
+        </div>
+        <div style="background-color:#ffffff; border-radius:16px; padding:40px 32px; border:1px solid #e5e7eb;">
+          <p style="margin:0 0 8px 0; font-size:24px;">⚠️</p>
+          <h1 style="margin:0 0 16px 0; font-size:20px; font-weight:700; color:#111827;">Your credits are running low</h1>
+          <p style="margin:0 0 20px 0; font-size:15px; line-height:1.6; color:#374151;">
+            Hi <strong>{user_name}</strong>,
+          </p>
+          <p style="margin:0 0 20px 0; font-size:15px; line-height:1.6; color:#374151;">
+            Your Omni credit balance has dropped to <strong style="color:#DC2626;">${balance:.2f}</strong>.
+            To avoid any interruption to your agents and workflows, please top up your credits.
+          </p>
+          <table cellpadding="0" cellspacing="0" border="0" style="background:#fef3c7; border:1px solid #fcd34d; border-radius:12px; padding:16px; margin:0 0 24px 0; width:100%;">
+            <tr>
+              <td style="font-size:14px; line-height:1.6; color:#92400e;">
+                <strong>Current balance:</strong> ${balance:.2f}<br/>
+                <strong>Minimum to run agents:</strong> $0.01
+              </td>
+            </tr>
+          </table>
+          <table cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px 0;">
+            <tr>
+              <td>
+                <a href="https://becomeomni.com/" style="background:#000000; color:#ffffff; padding:12px 28px; text-decoration:none; font-size:15px; font-weight:600; border-radius:12px; display:inline-block;">
+                  Top Up Credits →
+                </a>
+              </td>
+            </tr>
+          </table>
+          <p style="margin:0; font-size:13px; line-height:1.6; color:#9ca3af;">
+            You can also set up auto top-up in your billing settings so this never happens again.
+          </p>
+        </div>
+        <div style="text-align:center; margin-top:32px;">
+          <p style="font-size:12px; color:#9ca3af; margin:0;">
+            &copy; Omniscience Labs. All rights reserved.<br/>
+            You received this because your Omni credit balance fell below $1.00.
+          </p>
+        </div>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""
+
+    def _get_low_credit_alert_text(self, user_name: str, balance: float) -> str:
+        return f"""Hi {user_name},
+
+Your Omni credit balance has dropped to ${balance:.2f}.
+
+To avoid any interruption to your agents and workflows, please top up your credits.
+
+Current balance: ${balance:.2f}
+Minimum to run agents: $0.01
+
+Top up your credits here: https://becomeomni.com/
+
+You can also set up auto top-up in your billing settings so this never happens again.
+
+---
+© Omniscience Labs. All rights reserved.
+You received this because your Omni credit balance fell below $1.00."""
+
+
+email_service = EmailService()

--- a/backend/scripts/test_low_credit_alert.py
+++ b/backend/scripts/test_low_credit_alert.py
@@ -1,0 +1,149 @@
+"""
+Manual test script for the low-credit alert email.
+
+USAGE (from the backend/ directory):
+
+  Production sending (requires domain to be verified in MailTrap):
+    python scripts/test_low_credit_alert.py --email user@example.com
+
+  Sandbox / testing mode (no domain verification needed — get inbox ID from
+  MailTrap dashboard → Email Testing → your inbox → Integration):
+    python scripts/test_low_credit_alert.py --email user@example.com --sandbox --inbox-id 1234567
+
+Options:
+  --email       Recipient email address (required)
+  --name        Recipient display name (optional, derived from email if omitted)
+  --balance     Simulated credit balance shown in the email (default: 0.50)
+  --sandbox     Use MailTrap sandbox/testing mode (no domain verification needed)
+  --inbox-id    MailTrap inbox ID, required when --sandbox is set
+"""
+
+import argparse
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+load_dotenv()
+
+import mailtrap as mt
+
+
+def _get_client(sandbox: bool, inbox_id: int | None) -> mt.MailtrapClient:
+    token = os.getenv("MAILTRAP_API_TOKEN")
+    if not token:
+        print("❌  MAILTRAP_API_TOKEN is not set in .env")
+        sys.exit(1)
+
+    if sandbox:
+        return mt.MailtrapClient(token=token, api_host="sandbox.api.mailtrap.io")
+
+    return mt.MailtrapClient(token=token)
+
+
+def send_alert(
+    *,
+    to_email: str,
+    to_name: str,
+    balance: float,
+    sender_email: str,
+    sender_name: str,
+    sandbox: bool,
+    inbox_id: int | None,
+) -> bool:
+    client = _get_client(sandbox, inbox_id)
+
+    mail = mt.Mail(
+        sender=mt.Address(email=sender_email, name=sender_name),
+        to=[mt.Address(email=to_email, name=to_name)],
+        subject="⚠️ Your Omni credits are running low",
+        html=f"""
+        <p>Hi <strong>{to_name}</strong>,</p>
+        <p>Your Omni credit balance has dropped to
+           <strong style="color:#DC2626;">${balance:.2f}</strong>.</p>
+        <p>Please <a href="https://becomeomni.com/">top up your credits</a>
+           to avoid any interruption to your agents.</p>
+        """,
+        text=(
+            f"Hi {to_name},\n\n"
+            f"Your Omni credit balance has dropped to ${balance:.2f}.\n\n"
+            "Top up here: https://becomeomni.com/"
+        ),
+        category="low_credit_alert",
+    )
+
+    try:
+        if sandbox and inbox_id:
+            # Sandbox endpoint embeds inbox_id in the URL; the library doesn't
+            # support this, so we call the API directly.
+            import requests
+            token = os.getenv("MAILTRAP_API_TOKEN")
+            url = f"https://sandbox.api.mailtrap.io/api/send/{inbox_id}"
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            }
+            resp = requests.post(url, headers=headers, json=mail.api_data)
+            if not resp.ok:
+                print(f"❌  MailTrap sandbox error {resp.status_code}: {resp.text}")
+                return False
+            response = resp.json()
+        else:
+            response = client.send(mail)
+        print(f"   MailTrap response: {response}")
+        return True
+    except Exception as e:
+        print(f"❌  MailTrap error: {e}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send a test low-credit alert email via MailTrap")
+    parser.add_argument("--email", required=True, help="Recipient email address")
+    parser.add_argument("--name", default=None, help="Recipient display name")
+    parser.add_argument("--balance", type=float, default=0.50, help="Simulated balance (default: 0.50)")
+    parser.add_argument("--sandbox", action="store_true", help="Use MailTrap sandbox (no domain verification)")
+    parser.add_argument("--inbox-id", type=int, default=None, help="MailTrap inbox ID (required for --sandbox)")
+    args = parser.parse_args()
+
+    if args.sandbox and not args.inbox_id:
+        print("❌  --inbox-id is required when using --sandbox mode.")
+        print("    Find it in MailTrap → Email Testing → your inbox → Integration.")
+        sys.exit(1)
+
+    sender_email = os.getenv("MAILTRAP_SENDER_EMAIL", "support@omnisciencelabs.com")
+    sender_name  = os.getenv("MAILTRAP_SENDER_NAME",  "Omni Team")
+    to_name = args.name or args.email.split("@")[0].replace(".", " ").title()
+    mode = "SANDBOX" if args.sandbox else "PRODUCTION"
+
+    print(f"\n📧  Sending low-credit alert email [{mode}]")
+    print(f"    To      : {args.email} ({to_name})")
+    print(f"    Balance : ${args.balance:.2f}")
+    print(f"    From    : {sender_email} ({sender_name})")
+    if args.sandbox:
+        print(f"    Inbox ID: {args.inbox_id}")
+    print()
+
+    ok = send_alert(
+        to_email=args.email,
+        to_name=to_name,
+        balance=args.balance,
+        sender_email=sender_email,
+        sender_name=sender_name,
+        sandbox=args.sandbox,
+        inbox_id=args.inbox_id,
+    )
+
+    if ok:
+        print("✅  Email sent successfully!")
+        if args.sandbox:
+            print("    Check MailTrap → Email Testing → your inbox.")
+        else:
+            print("    Check your inbox (or MailTrap sending logs).")
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/test_low_credit_alert.py
+++ b/backend/scripts/test_low_credit_alert.py
@@ -25,6 +25,7 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from dotenv import load_dotenv
+
 load_dotenv()
 
 import mailtrap as mt
@@ -54,22 +55,17 @@ def send_alert(
 ) -> bool:
     client = _get_client(sandbox, inbox_id)
 
+    from core.services.email import email_service
+
+    html_content = email_service._get_low_credit_alert_template(to_name, balance)
+    text_content = email_service._get_low_credit_alert_text(to_name, balance)
+
     mail = mt.Mail(
         sender=mt.Address(email=sender_email, name=sender_name),
         to=[mt.Address(email=to_email, name=to_name)],
         subject="⚠️ Your Omni credits are running low",
-        html=f"""
-        <p>Hi <strong>{to_name}</strong>,</p>
-        <p>Your Omni credit balance has dropped to
-           <strong style="color:#DC2626;">${balance:.2f}</strong>.</p>
-        <p>Please <a href="https://becomeomni.com/">top up your credits</a>
-           to avoid any interruption to your agents.</p>
-        """,
-        text=(
-            f"Hi {to_name},\n\n"
-            f"Your Omni credit balance has dropped to ${balance:.2f}.\n\n"
-            "Top up here: https://becomeomni.com/"
-        ),
+        html=html_content,
+        text=text_content,
         category="low_credit_alert",
     )
 
@@ -78,6 +74,7 @@ def send_alert(
             # Sandbox endpoint embeds inbox_id in the URL; the library doesn't
             # support this, so we call the API directly.
             import requests
+
             token = os.getenv("MAILTRAP_API_TOKEN")
             url = f"https://sandbox.api.mailtrap.io/api/send/{inbox_id}"
             headers = {
@@ -99,12 +96,25 @@ def send_alert(
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Send a test low-credit alert email via MailTrap")
+    parser = argparse.ArgumentParser(
+        description="Send a test low-credit alert email via MailTrap"
+    )
     parser.add_argument("--email", required=True, help="Recipient email address")
     parser.add_argument("--name", default=None, help="Recipient display name")
-    parser.add_argument("--balance", type=float, default=0.50, help="Simulated balance (default: 0.50)")
-    parser.add_argument("--sandbox", action="store_true", help="Use MailTrap sandbox (no domain verification)")
-    parser.add_argument("--inbox-id", type=int, default=None, help="MailTrap inbox ID (required for --sandbox)")
+    parser.add_argument(
+        "--balance", type=float, default=0.50, help="Simulated balance (default: 0.50)"
+    )
+    parser.add_argument(
+        "--sandbox",
+        action="store_true",
+        help="Use MailTrap sandbox (no domain verification)",
+    )
+    parser.add_argument(
+        "--inbox-id",
+        type=int,
+        default=None,
+        help="MailTrap inbox ID (required for --sandbox)",
+    )
     args = parser.parse_args()
 
     if args.sandbox and not args.inbox_id:
@@ -113,7 +123,7 @@ def main():
         sys.exit(1)
 
     sender_email = os.getenv("MAILTRAP_SENDER_EMAIL", "support@omnisciencelabs.com")
-    sender_name  = os.getenv("MAILTRAP_SENDER_NAME",  "Omni Team")
+    sender_name = os.getenv("MAILTRAP_SENDER_NAME", "Omni Team")
     to_name = args.name or args.email.split("@")[0].replace(".", " ").title()
     mode = "SANDBOX" if args.sandbox else "PRODUCTION"
 

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,9 @@ def load_existing_env_vars():
         "storage": {
         },
         "email": {
+            "MAILTRAP_API_TOKEN": backend_env.get("MAILTRAP_API_TOKEN", ""),
+            "MAILTRAP_SENDER_EMAIL": backend_env.get("MAILTRAP_SENDER_EMAIL", ""),
+            "MAILTRAP_SENDER_NAME": backend_env.get("MAILTRAP_SENDER_NAME", ""),
         },
         "llamacloud": {
             "LLAMA_CLOUD_API_KEY": backend_env.get("LLAMA_CLOUD_API_KEY", ""),
@@ -327,7 +330,7 @@ class SetupWizard:
             else:
                 self.env_vars[key] = value
 
-        self.total_steps = 18
+        self.total_steps = 19
 
     def show_current_config(self):
         """Shows the current configuration status."""
@@ -451,6 +454,14 @@ class SetupWizard:
             config_items.append(
                 f"{Colors.CYAN}○{Colors.ENDC} LlamaCloud (optional)")
 
+        # Check MailTrap email configuration (optional)
+        if self.env_vars.get("email", {}).get("MAILTRAP_API_TOKEN"):
+            config_items.append(
+                f"{Colors.GREEN}✓{Colors.ENDC} MailTrap Email (optional)")
+        else:
+            config_items.append(
+                f"{Colors.CYAN}○{Colors.ENDC} MailTrap Email (optional)")
+
         if any("✓" in item for item in config_items):
             print_info("Current configuration status:")
             for item in config_items:
@@ -519,7 +530,7 @@ class SetupWizard:
                 if os.path.exists(PROGRESS_FILE):
                     os.remove(PROGRESS_FILE)
                 self.env_vars = {}
-                self.total_steps = 18
+                self.total_steps = 19
                 self.current_step = 0
                 # Continue with normal setup
             elif choice == "4":
@@ -545,11 +556,11 @@ class SetupWizard:
             self.run_step_optional(11, self.collect_mcp_keys, "MCP Configuration (Optional)")
             self.run_step_optional(12, self.collect_composio_keys, "Composio Integration (Optional)")
             self.run_step_optional(13, self.collect_llamacloud_keys, "LlamaCloud Configuration (Optional)")
-            # Removed duplicate webhook collection step
-            self.run_step(14, self.configure_env_files)
-            self.run_step(15, self.setup_supabase_database)
-            self.run_step(16, self.install_dependencies)
-            self.run_step(17, self.start_suna)
+            self.run_step_optional(14, self.collect_mailtrap_keys, "MailTrap Email Configuration (Optional)")
+            self.run_step(15, self.configure_env_files)
+            self.run_step(16, self.setup_supabase_database)
+            self.run_step(17, self.install_dependencies)
+            self.run_step(18, self.start_suna)
 
             self.final_instructions()
 
@@ -1564,9 +1575,69 @@ class SetupWizard:
             print_info("Skipping LlamaCloud configuration.")
 
 
+    def collect_mailtrap_keys(self):
+        """Collects optional MailTrap configuration for transactional email sending."""
+        print_step(14, self.total_steps, "Collecting MailTrap Email Configuration (Optional)")
+
+        existing_token = self.env_vars.get("email", {}).get("MAILTRAP_API_TOKEN", "")
+        if existing_token:
+            print_info(
+                f"Found existing MailTrap API token: {mask_sensitive_value(existing_token)}"
+            )
+            print_info("Press Enter to keep current values or type new ones.")
+        else:
+            print_info(
+                "MailTrap is used to send transactional emails (e.g. low-credit alerts, welcome emails)."
+            )
+            print_info(
+                "Get your API token at: https://mailtrap.io/ → Email Sending → API Tokens"
+            )
+            print_info("You can skip this step and add it to backend/.env later.")
+
+        if "email" not in self.env_vars:
+            self.env_vars["email"] = {}
+
+        api_token = self._get_input(
+            "Enter your MailTrap API token (or press Enter to skip): ",
+            validate_api_key,
+            "The token seems invalid, but continuing. You can edit it later in backend/.env",
+            allow_empty=True,
+            default_value=existing_token,
+        )
+
+        if not api_token:
+            print_info("Skipping MailTrap configuration.")
+            return
+
+        self.env_vars["email"]["MAILTRAP_API_TOKEN"] = api_token
+
+        existing_sender_email = self.env_vars["email"].get("MAILTRAP_SENDER_EMAIL", "")
+        sender_email = self._get_input(
+            "Enter the sender email address (e.g. support@yourdomain.com): ",
+            lambda v, allow_empty=False: allow_empty or bool(v and "@" in v),
+            "Please enter a valid email address.",
+            allow_empty=True,
+            default_value=existing_sender_email or "support@omnisciencelabs.com",
+        )
+        self.env_vars["email"]["MAILTRAP_SENDER_EMAIL"] = sender_email or "support@omnisciencelabs.com"
+
+        existing_sender_name = self.env_vars["email"].get("MAILTRAP_SENDER_NAME", "")
+        sender_name_input = input(
+            f"Enter the sender display name [{Colors.GREEN}{existing_sender_name or 'Omni Team'}{Colors.ENDC}]: "
+        ).strip()
+        self.env_vars["email"]["MAILTRAP_SENDER_NAME"] = (
+            sender_name_input or existing_sender_name or "Omni Team"
+        )
+
+        print_success(
+            f"MailTrap configured — emails will be sent from "
+            f"{self.env_vars['email']['MAILTRAP_SENDER_EMAIL']} "
+            f"({self.env_vars['email']['MAILTRAP_SENDER_NAME']})"
+        )
+
     def configure_env_files(self):
         """Configures and writes the .env files for frontend and backend."""
-        print_step(14, self.total_steps, "Configuring Environment Files")
+        print_step(15, self.total_steps, "Configuring Environment Files")
 
         # --- Backend .env ---
         is_docker = self.env_vars["setup_method"] == "docker"
@@ -1665,7 +1736,7 @@ class SetupWizard:
 
     def setup_supabase_database(self):
         """Applies database migrations to Supabase (local or cloud)."""
-        print_step(15, self.total_steps, "Setting up Supabase Database")
+        print_step(16, self.total_steps, "Setting up Supabase Database")
 
         print_info(
             "This step will apply database migrations to your Supabase instance."
@@ -1813,7 +1884,7 @@ class SetupWizard:
 
     def install_dependencies(self):
         """Installs frontend and backend dependencies for manual setup."""
-        print_step(16, self.total_steps, "Installing Dependencies")
+        print_step(17, self.total_steps, "Installing Dependencies")
         if self.env_vars["setup_method"] == "docker":
             print_info(
                 "Skipping dependency installation for Docker setup (will be handled by Docker Compose)."
@@ -1856,7 +1927,7 @@ class SetupWizard:
 
     def start_suna(self):
         """Starts Suna using Docker Compose or shows instructions for manual startup."""
-        print_step(17, self.total_steps, "Starting Suna")
+        print_step(18, self.total_steps, "Starting Suna")
         if self.env_vars["setup_method"] == "docker":
             print_info("Starting Suna with Docker Compose...")
             try:


### PR DESCRIPTION
Automatically emails users when their credit balance drops below $1.00, using the existing MailTrap setup.
Changes:
**email.py** — added send_low_credit_alert_email() with HTML + plain-text templates; replaced all Kortix branding with Omni/Omniscience Labs
**credits.py** — hooks into deduct_credits() to fire the alert as a non-blocking background task; Redis-based deduplication guard limits alerts to once per user per day
**notification_service.py** — bridge that resolves user email/name from Supabase auth and calls the email service
**notification_admin_api.py** — added POST /admin/notifications/test-low-credit-alert endpoint for manual testing without touching credits
**setup.py** — added optional MailTrap step (API token, sender email, sender name) to the setup wizard so new installs can configure it interactively
**scripts/test_low_credit_alert.py** — standalone CLI script for local testing with sandbox or production MailTrap mode