### PR TITLE
feat(memory): migrate from mem0 to supermemory

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -47,6 +47,7 @@ import sys
 from core.triggers import api as triggers_api
 from core.services import api_keys_api
 from core.notifications import api as notifications_api
+from core.services import memory_api
 
 
 if sys.platform == "win32":
@@ -315,6 +316,8 @@ api_router.include_router(template_api.router, prefix="/templates")
 api_router.include_router(presentations_api.router, prefix="/presentation-templates")
 
 api_router.include_router(transcription_api.router)
+
+api_router.include_router(memory_api.router)
 
 from core.knowledge_base import api as knowledge_base_api
 api_router.include_router(knowledge_base_api.router)

--- a/backend/core/agentpress/thread_manager.py
+++ b/backend/core/agentpress/thread_manager.py
@@ -13,6 +13,7 @@ from core.agentpress.context_manager import ContextManager
 from core.agentpress.response_processor import ResponseProcessor, ProcessorConfig
 from core.agentpress.error_processor import ErrorProcessor
 from core.services.supabase import DBConnection
+from core.services.memory_integration import retrieve_relevant_memories
 from core.utils.logger import logger
 from langfuse.client import StatefulGenerationClient, StatefulTraceClient
 from core.services.langfuse import langfuse
@@ -518,6 +519,37 @@ class ThreadManager:
                     )
                     logger.debug(f"⏱️ [TIMING] Compression check: {(time.time() - compress_start) * 1000:.1f}ms")
                     messages = compressed_messages
+
+            # inject relevant memories into system prompt for context-aware responses
+            try:
+                query = latest_user_message_content
+                if not query and messages:
+                    for m in reversed(messages):
+                        if isinstance(m, dict) and m.get("role") == "user":
+                            query = m.get("content", "")
+                            if isinstance(query, list):
+                                query = " ".join(
+                                    (c.get("text", "") if isinstance(c, dict) else str(c) for c in query)
+                                )
+                            else:
+                                query = str(query)
+                            break
+                if query:
+                    memory_context = await retrieve_relevant_memories(
+                        self.db, thread_id, query, limit=8
+                    )
+                    if memory_context:
+                        if isinstance(system_prompt, dict):
+                            system_prompt = dict(system_prompt)
+                            system_prompt["content"] = memory_context + "\n\n" + (system_prompt.get("content") or "")
+                        else:
+                            system_prompt = memory_context + "\n\n" + str(system_prompt)
+                        logger.info(
+                            "Injected relevant memories into system prompt for cross-thread context",
+                            extra={"thread_id": thread_id, "query_preview": query[:60]},
+                        )
+            except Exception as mem_err:
+                logger.debug(f"Memory retrieval skipped: {mem_err}")
 
             # Check if cache needs rebuild due to compression
             force_rebuild = False

--- a/backend/core/services/memory.py
+++ b/backend/core/services/memory.py
@@ -1,0 +1,411 @@
+"""
+Memory service using Supermemory for AI-powered memory management.
+
+This service provides functionality for storing and retrieving memories
+associated with user message threads. It integrates with the Supermemory
+platform to provide context-aware memory storage and retrieval for AI conversations.
+
+Features:
+- Add memories before/after AI interactions
+- Search memories by context or thread
+- User-specific memory isolation via container tags
+- Thread-based memory organization
+"""
+
+import asyncio
+from typing import List, Dict, Any, Optional, Union
+from core.utils.config import config
+from core.utils.logger import logger
+from supermemory import AsyncSupermemory
+from supermemory import APIError as SupermemoryAPIError
+
+def _clip_message_content(content: str, max_length: int = 4000) -> str:
+    """Clip message content to prevent excessively large memory entries."""
+    if len(content) <= max_length:
+        return content
+    return content[: max_length - 3] + "..."
+
+
+def _content_to_string(content: Union[str, List[Dict[str, str]]]) -> str:
+    """Normalize content to a single string for storage."""
+    if isinstance(content, str):
+        return _clip_message_content(content)
+    parts = []
+    for msg in content:
+        if isinstance(msg, dict):
+            role = msg.get("role", "user")
+            text = msg.get("content", "")
+            if text:
+                parts.append(f"{role.capitalize()}: {_clip_message_content(str(text))}")
+        else:
+            parts.append(_clip_message_content(str(msg)))
+    return "\n\n".join(parts) if parts else ""
+
+
+def _container_tags(user_id: str, thread_id: Optional[str] = None) -> List[str]:
+    """Build Supermemory container_tags for user and optional thread scoping."""
+    tags = [f"user_{user_id}"]
+    if thread_id:
+        tags.append(f"thread_{thread_id}")
+    return tags
+
+
+def _is_likely_metadata(s: str) -> bool:
+    """Return True if s looks like a timestamp, UUID, ID, or other non-content metadata."""
+    if not s or len(s) > 2000:
+        return len(s) > 2000  # Treat very long as potential content
+    s = s.strip()
+    if len(s) < 15:
+        return True
+    # ISO timestamp: 2026-02-23T17:49:56.430Z
+    if len(s) >= 20 and s[4] == "-" and s[7] == "-" and "T" in s[:25]:
+        return True
+    # UUID-like
+    if len(s) == 36 and s.count("-") == 4:
+        return True
+    # Document/memory ID: short alphanumeric, no spaces (e.g. p4VePZhZqB3WZkHXpWJ1yX)
+    if 10 <= len(s) <= 50 and s.isalnum() and not any(c.isspace() for c in s):
+        return True
+    return False
+
+
+class MemoryError(Exception):
+    """Base exception for memory-related errors."""
+
+    pass
+
+
+class MemoryService:
+    """
+    Service for managing AI memories using Supermemory.
+
+    Provides methods for adding, searching, and managing memories
+    associated with user conversations and AI interactions.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the memory service with Supermemory async client."""
+        self.api_key = getattr(config, "SUPERMEMORY_API_KEY", None)
+        self.client = None
+        if not self.api_key:
+            logger.warning("SUPERMEMORY_API_KEY not found in environment variables")
+            return
+        if AsyncSupermemory is None:
+            logger.warning("Supermemory SDK not installed or failed to import")
+            return
+        try:
+            timeout = getattr(config, "SUPERMEMORY_REQUEST_TIMEOUT", 20.0)
+            max_retries = getattr(config, "SUPERMEMORY_MAX_RETRIES", 4)
+            # Coerce to numeric types in case config loaded from env as string
+            timeout = float(timeout) if timeout is not None else 20.0
+            max_retries = int(max_retries) if max_retries is not None else 4
+            self.client = AsyncSupermemory(
+                api_key=self.api_key,
+                timeout=timeout,
+                max_retries=max_retries,
+            )
+            logger.info("Memory service (Supermemory) initialized successfully")
+        except Exception as e:
+            logger.error(f"Failed to initialize Supermemory client: {str(e)}")
+            self.client = None
+
+    def is_available(self) -> bool:
+        """Check if the memory service is available."""
+        return self.client is not None
+
+    async def add_memory(
+        self,
+        content: Union[str, List[Dict[str, str]]],
+        user_id: str,
+        thread_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Add a memory to the user's memory store.
+
+        Args:
+            content: The memory content to store - either a string or list of message dicts
+            user_id: User identifier for memory isolation
+            thread_id: Optional thread identifier for conversation context
+            metadata: Additional metadata to store with the memory
+
+        Returns:
+            bool: True if memory was added successfully, False otherwise
+        """
+        if not self.client:
+            logger.error("Cannot add memory: Memory service not available")
+            return False
+        tags = _container_tags(user_id, thread_id)
+        body_metadata = dict(metadata) if metadata else {}
+        body_metadata["user_id"] = user_id
+        if thread_id:
+            body_metadata["thread_id"] = thread_id
+        try:
+            text = _content_to_string(content)
+            await self.client.add(
+                content=text,
+                container_tags=tags,
+                metadata=body_metadata,
+            )
+            logger.debug(
+                f"Memory added successfully for user {user_id}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+            )
+            return True
+        except SupermemoryAPIError as e:
+            logger.error(
+                f"Supermemory add failed: {e}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+                exc_info=True,
+            )
+            return False
+        except Exception as e:
+            logger.error(
+                f"Error adding memory for user {user_id}: {e}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+                exc_info=True,
+            )
+            return False
+
+    async def search_memories(
+        self,
+        query: str,
+        user_id: str,
+        thread_id: Optional[str] = None,
+        limit: int = 10,
+        version: str = "v2",
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search memories for a user based on query.
+
+        Args:
+            query: Search query text
+            user_id: User identifier for memory isolation
+            thread_id: Optional thread identifier to scope search
+            limit: Maximum number of memories to return
+            version: API version (unused, for compatibility)
+            filters: Optional filters (unused for v3 search)
+
+        Returns:
+            List of memory dictionaries with 'memory' or 'text' and 'id'
+        """
+        if not self.client:
+            logger.error("Cannot search memories: Memory service not available")
+            return []
+        tags = _container_tags(user_id, thread_id)
+        try:
+            response = await self.client.search.execute(
+                q=query,
+                container_tags=tags,
+                limit=limit,
+            )
+            results = getattr(response, "results", None) or getattr(
+                response, "data", []
+            )
+            out: List[Dict[str, Any]] = []
+            for item in results or []:
+                if hasattr(item, "model_dump"):
+                    d = item.model_dump()
+                    # Supermemory search.execute returns Result: content, summary, chunks[{content}], document_id
+                    doc_id = d.get("document_id") or d.get("documentId") or d.get("id")
+                elif isinstance(item, dict):
+                    d = dict(item)
+                    doc_id = d.get("document_id") or d.get("documentId") or d.get("id")
+                else:
+                    d = {"id": getattr(item, "id", None), "memory": getattr(item, "memory", None) or getattr(item, "text", None) or getattr(item, "chunk", str(item))}
+                    doc_id = d.get("id")
+                # Extract text: Supermemory Result has content, summary, or chunks[].content
+                text = ""
+                if isinstance(d.get("content"), str) and d["content"].strip() and not _is_likely_metadata(d["content"]):
+                    text = d["content"].strip()
+                if not text and isinstance(d.get("summary"), str) and d["summary"].strip() and not _is_likely_metadata(d["summary"]):
+                    text = d["summary"].strip()
+                if not text:
+                    chunks = d.get("chunks") or []
+                    if isinstance(chunks, list):
+                        parts = []
+                        for c in chunks:
+                            if isinstance(c, dict) and isinstance(c.get("content"), str) and c["content"].strip():
+                                parts.append(c["content"].strip())
+                            elif hasattr(c, "content"):
+                                parts.append(str(c.content).strip())
+                        if parts:
+                            text = "\n".join(parts)
+                if not text:
+                    for key in ("memory", "chunk", "text", "body", "value", "data"):
+                        raw = d.get(key)
+                        if isinstance(raw, str) and raw.strip() and not _is_likely_metadata(raw):
+                            text = raw.strip()
+                            break
+                if not text:
+                    skip_keys = ("id", "metadata", "updatedAt", "createdAt", "updated_at", "created_at", "version", "document_id", "documentId", "chunks")
+                    for k, v in d.items():
+                        if k in skip_keys or not isinstance(v, str):
+                            continue
+                        if v.strip() and not _is_likely_metadata(v):
+                            text = v.strip()
+                            break
+                out.append({"id": doc_id, "memory": text, "text": text, "metadata": d.get("metadata", {})})
+            if out and not any(o.get("memory") or o.get("text") for o in out) and results:
+                first = results[0]
+                try:
+                    raw_d = first.model_dump() if hasattr(first, "model_dump") else (first if isinstance(first, dict) else {})
+                    logger.warning(
+                        "Supermemory search: all results had empty text; first item repr: %s",
+                        {k: repr(v)[:300] for k, v in (raw_d or {}).items()},
+                        extra={"user_id": user_id},
+                    )
+                except Exception:
+                    pass
+            logger.debug(
+                f"Found {len(out)} memories for user {user_id}",
+                extra={"user_id": user_id, "thread_id": thread_id, "query": query[:50]},
+            )
+            return out
+        except SupermemoryAPIError as e:
+            logger.error(
+                f"Supermemory search failed: {e}",
+                extra={"user_id": user_id, "thread_id": thread_id, "query": query[:50]},
+                exc_info=True,
+            )
+            return []
+        except Exception as e:
+            logger.error(
+                f"Error searching memories for user {user_id}: {e}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+                exc_info=True,
+            )
+            return []
+
+    async def get_thread_memories(
+        self,
+        user_id: str,
+        thread_id: str,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """
+        Get all memories for a specific thread.
+
+        Args:
+            user_id: User identifier
+            thread_id: Thread identifier
+            limit: Maximum number of memories to return
+
+        Returns:
+            List of memories for the thread
+        """
+        if not self.client:
+            logger.error("Cannot get thread memories: Memory service not available")
+            return []
+        tags = _container_tags(user_id, thread_id)
+        try:
+            response = await self.client.documents.list(
+                container_tags=tags,
+                limit=min(limit, 100),
+            )
+            items = getattr(response, "data", None) or getattr(
+                response, "documents", None
+            ) or []
+            out: List[Dict[str, Any]] = []
+            for item in items or []:
+                if hasattr(item, "model_dump"):
+                    d = item.model_dump()
+                elif isinstance(item, dict):
+                    d = item
+                else:
+                    d = {"id": getattr(item, "id", None), "memory": getattr(item, "content", None) or getattr(item, "memory", "")}
+                text = d.get("content") or d.get("memory") or d.get("text", "")
+                out.append({"id": d.get("id"), "memory": text, "text": text, "metadata": d.get("metadata", {})})
+            logger.debug(
+                f"Retrieved {len(out)} memories for thread {thread_id}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+            )
+            return out
+        except SupermemoryAPIError as e:
+            logger.error(
+                f"Supermemory list failed: {e}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+                exc_info=True,
+            )
+            return []
+        except Exception as e:
+            logger.error(
+                f"Error getting thread memories: {e}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+                exc_info=True,
+            )
+            return []
+
+    async def delete_memory(self, memory_id: str, user_id: str) -> bool:
+        """
+        Delete a specific memory.
+
+        Args:
+            memory_id: The ID of the memory to delete
+            user_id: User identifier for authorization
+
+        Returns:
+            bool: True if deletion was successful, False otherwise
+        """
+        if not self.client:
+            logger.error("Cannot delete memory: Memory service not available")
+            return False
+        try:
+            await self.client.documents.delete(id=memory_id)
+            logger.info(
+                f"Memory {memory_id} deleted successfully",
+                extra={"user_id": user_id, "memory_id": memory_id},
+            )
+            return True
+        except SupermemoryAPIError as e:
+            logger.error(
+                f"Supermemory delete failed: {e}",
+                extra={"user_id": user_id, "memory_id": memory_id},
+                exc_info=True,
+            )
+            return False
+        except Exception as e:
+            logger.error(
+                f"Error deleting memory {memory_id}: {e}",
+                extra={"user_id": user_id, "memory_id": memory_id},
+                exc_info=True,
+            )
+            return False
+
+    async def clear_thread_memories(self, user_id: str, thread_id: str) -> bool:
+        """
+        Clear all memories for a specific thread.
+
+        Args:
+            user_id: User identifier
+            thread_id: Thread identifier
+
+        Returns:
+            bool: True if clearing was successful, False otherwise
+        """
+        try:
+            thread_memories = await self.get_thread_memories(user_id, thread_id, limit=500)
+            if not thread_memories:
+                logger.info(f"No memories found for thread {thread_id}")
+                return True
+            success_count = 0
+            for memory in thread_memories:
+                mid = memory.get("id")
+                if mid and await self.delete_memory(mid, user_id):
+                    success_count += 1
+            logger.info(
+                f"Cleared {success_count}/{len(thread_memories)} memories for thread {thread_id}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+            )
+            return success_count == len(thread_memories)
+        except Exception as e:
+            logger.error(
+                f"Error clearing thread memories: {e}",
+                extra={"user_id": user_id, "thread_id": thread_id},
+                exc_info=True,
+            )
+            return False
+
+
+memory_service = MemoryService()

--- a/backend/core/services/memory_api.py
+++ b/backend/core/services/memory_api.py
@@ -1,0 +1,295 @@
+"""
+Memory API endpoints for managing AI memories.
+
+This module provides FastAPI endpoints for memory operations including
+adding, searching, and managing memories associated with user conversations.
+"""
+
+from typing import List, Dict, Any, Optional
+from fastapi import APIRouter, HTTPException, Depends, status, Request
+from pydantic import BaseModel, Field
+from core.utils.auth_utils import verify_and_get_user_id_from_jwt
+from core.services.memory import memory_service
+from core.utils.logger import logger
+from core.utils.config import config, EnvMode
+
+router = APIRouter(prefix="/memory", tags=["memory"])
+
+
+async def get_memory_user_id(request: Request) -> str:
+    """
+    Resolve user_id for memory endpoints.
+    In local mode, accepts X-Test-User-Id header to bypass JWT for testing.
+    Otherwise requires valid JWT.
+    """
+    if config.ENV_MODE == EnvMode.LOCAL:
+        test_user_id = request.headers.get("X-Test-User-Id", "").strip()
+        if test_user_id:
+            logger.debug(f"Using X-Test-User-Id for memory API (local only): {test_user_id[:8]}...")
+            return test_user_id
+    return await verify_and_get_user_id_from_jwt(request)
+
+
+class AddMemoryRequest(BaseModel):
+    """Request model for adding a memory."""
+
+    text: str = Field(..., description="Memory content to store")
+    thread_id: Optional[str] = Field(
+        None, description="Thread identifier for conversation context"
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        None, description="Additional metadata"
+    )
+
+
+class SearchMemoriesRequest(BaseModel):
+    """Request model for searching memories."""
+
+    query: str = Field(..., description="Search query text")
+    thread_id: Optional[str] = Field(
+        None, description="Optional thread identifier to scope search"
+    )
+    limit: int = Field(
+        10,
+        description="Maximum number of memories to return",
+        ge=1,
+        le=100,
+    )
+    version: str = Field(
+        "v2",
+        description="API version to use (v1 or v2)",
+    )
+    filters: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Optional filters for v2 API",
+    )
+
+
+class AddMemoryResponse(BaseModel):
+    """Response model for adding a memory."""
+
+    success: bool
+    message: str
+
+
+class SearchMemoriesResponse(BaseModel):
+    """Response model for memory search."""
+
+    memories: List[Dict[str, Any]]
+    count: int
+
+
+class DeleteMemoryResponse(BaseModel):
+    """Response model for memory deletion."""
+
+    success: bool
+    message: str
+
+
+class HealthResponse(BaseModel):
+    """Response model for service health check."""
+
+    available: bool
+    message: str
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health_check():
+    """Check if the memory service is available."""
+    try:
+        available = memory_service.is_available()
+        message = (
+            "Memory service is available"
+            if available
+            else "Memory service is not configured"
+        )
+        return HealthResponse(available=available, message=message)
+    except Exception as e:
+        logger.error(f"Memory service health check failed: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Memory service health check failed",
+        )
+
+
+@router.post("/add", response_model=AddMemoryResponse)
+async def add_memory(
+    request: AddMemoryRequest,
+    user_id: str = Depends(get_memory_user_id),
+):
+    """
+    Add a memory for the current user.
+
+    Memories can be optionally associated with a specific thread.
+    """
+    try:
+        if not memory_service.is_available():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Memory service is not available",
+            )
+        success = await memory_service.add_memory(
+            content=request.text,
+            user_id=user_id,
+            thread_id=request.thread_id,
+            metadata=request.metadata,
+        )
+        if success:
+            return AddMemoryResponse(
+                success=True,
+                message="Memory added successfully",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to add memory",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error adding memory: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while adding the memory",
+        )
+
+
+@router.post("/search", response_model=SearchMemoriesResponse)
+async def search_memories(
+    request: SearchMemoriesRequest,
+    user_id: str = Depends(get_memory_user_id),
+):
+    """
+    Search memories for the current user.
+
+    Results can be optionally filtered by thread ID.
+    """
+    try:
+        if not memory_service.is_available():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Memory service is not available",
+            )
+        memories = await memory_service.search_memories(
+            query=request.query,
+            user_id=user_id,
+            thread_id=request.thread_id,
+            limit=request.limit,
+            version=request.version,
+            filters=request.filters,
+        )
+        return SearchMemoriesResponse(memories=memories, count=len(memories))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error searching memories: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while searching memories",
+        )
+
+
+@router.get("/thread/{thread_id}", response_model=SearchMemoriesResponse)
+async def get_thread_memories(
+    thread_id: str,
+    limit: int = 50,
+    user_id: str = Depends(get_memory_user_id),
+):
+    """
+    Get all memories for a specific thread.
+    """
+    try:
+        if not memory_service.is_available():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Memory service is not available",
+            )
+        memories = await memory_service.get_thread_memories(
+            user_id=user_id,
+            thread_id=thread_id,
+            limit=min(limit, 100),
+        )
+        return SearchMemoriesResponse(memories=memories, count=len(memories))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting thread memories: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while retrieving thread memories",
+        )
+
+
+@router.delete("/memory/{memory_id}", response_model=DeleteMemoryResponse)
+async def delete_memory(
+    memory_id: str,
+    user_id: str = Depends(get_memory_user_id),
+):
+    """
+    Delete a specific memory.
+    """
+    try:
+        if not memory_service.is_available():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Memory service is not available",
+            )
+        success = await memory_service.delete_memory(
+            memory_id=memory_id,
+            user_id=user_id,
+        )
+        if success:
+            return DeleteMemoryResponse(
+                success=True,
+                message="Memory deleted successfully",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Memory not found or could not be deleted",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting memory: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while deleting the memory",
+        )
+
+
+@router.delete("/thread/{thread_id}", response_model=DeleteMemoryResponse)
+async def clear_thread_memories(
+    thread_id: str,
+    user_id: str = Depends(get_memory_user_id),
+):
+    """
+    Clear all memories for a specific thread.
+
+    Use with caution as this operation cannot be undone.
+    """
+    try:
+        if not memory_service.is_available():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Memory service is not available",
+            )
+        success = await memory_service.clear_thread_memories(
+            user_id=user_id,
+            thread_id=thread_id,
+        )
+        if success:
+            return DeleteMemoryResponse(
+                success=True,
+                message="Thread memories cleared successfully",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to clear thread memories",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error clearing thread memories: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred while clearing thread memories",
+        )

--- a/backend/core/services/memory_integration.py
+++ b/backend/core/services/memory_integration.py
@@ -1,0 +1,293 @@
+"""
+Memory integration helper functions for AI conversation storage.
+
+This module provides helper functions to integrate memory storage
+at the end of AI interactions and retrieval before sending messages to the agent.
+"""
+
+import hashlib
+import json
+from typing import List, Dict, Any, Optional
+from core.services.memory import memory_service
+from core.services.supabase import DBConnection
+from core.services import redis
+from core.utils.logger import logger
+from core.utils.config import config
+
+
+# Constants for memory formatting
+MEMORY_CONTEXT_HEADER = "**Relevant Context from Previous Conversations:**\n"
+MEMORY_CONTEXT_FOOTER = "\n**Current Conversation:**"
+
+
+def _compute_memory_hash(conversation_messages: List[Dict[str, Any]]) -> str:
+    """Compute a hash of conversation messages for deduplication."""
+    message_strs = []
+    for msg in conversation_messages[-5:]:
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        message_strs.append(f"{role}:{content}")
+    content_to_hash = "|".join(message_strs)
+    return hashlib.sha256(content_to_hash.encode("utf-8")).hexdigest()[:16]
+
+
+def _generate_memory_cache_key(
+    user_id: str, thread_id: str, query: str, limit: int
+) -> str:
+    """Generate a cache key for memory retrieval."""
+    key_components = f"{user_id}:{thread_id}:{query}:{limit}"
+    return f"mem_cache:{hashlib.sha256(key_components.encode()).hexdigest()[:16]}"
+
+
+async def get_user_id_from_thread(db: DBConnection, thread_id: str) -> Optional[str]:
+    """
+    Get user_id (account_id) from thread_id.
+
+    Args:
+        db: Database connection
+        thread_id: Thread identifier
+
+    Returns:
+        User ID (account_id) or None if not found
+    """
+    try:
+        client = await db.client
+        result = (
+            await client.table("threads")
+            .select("account_id")
+            .eq("thread_id", thread_id)
+            .execute()
+        )
+        if result.data and len(result.data) > 0:
+            user_id = result.data[0]["account_id"]
+            logger.debug(f"Retrieved user_id {user_id} for thread {thread_id}")
+            return user_id
+        logger.warning(f"No user found for thread {thread_id}")
+        return None
+    except Exception as e:
+        logger.error(f"Error getting user_id from thread {thread_id}: {e}")
+        return None
+
+
+async def get_recent_conversation_messages(
+    db: DBConnection, thread_id: str, limit: int = 20
+) -> List[Dict[str, Any]]:
+    """
+    Get recent conversation messages from a thread for memory storage.
+
+    Args:
+        db: Database connection
+        thread_id: Thread identifier
+        limit: Maximum number of recent messages to retrieve
+
+    Returns:
+        List of message dictionaries with role and content
+    """
+    try:
+        client = await db.client
+        result = (
+            await client.table("messages")
+            .select("content, type, created_at")
+            .eq("thread_id", thread_id)
+            .eq("is_llm_message", True)
+            .order("created_at", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        if not result.data:
+            return []
+        messages = []
+        for msg_data in reversed(result.data):
+            content = msg_data["content"]
+            if isinstance(content, str):
+                try:
+                    content = json.loads(content)
+                except json.JSONDecodeError:
+                    continue
+            role = content.get("role", msg_data["type"])
+            message_content = content.get("content", "")
+            if role and message_content:
+                messages.append({"role": role, "content": str(message_content)})
+        return messages
+    except Exception as e:
+        logger.error(f"Error getting conversation messages from thread {thread_id}: {e}")
+        return []
+
+
+async def store_conversation_memory(
+    db: DBConnection,
+    thread_id: str,
+    conversation_messages: Optional[List[Dict[str, Any]]] = None,
+    additional_context: Optional[str] = None,
+    agent_run_id: Optional[str] = None,
+) -> bool:
+    """
+    Store conversation memory at the end of an AI interaction.
+
+    Args:
+        db: Database connection
+        thread_id: Thread identifier
+        conversation_messages: Optional pre-fetched messages, will fetch if None
+        additional_context: Additional context to include in memory
+        agent_run_id: Optional agent run ID for deduplication
+
+    Returns:
+        True if memory storage was successful, False otherwise
+    """
+    try:
+        if not memory_service.is_available():
+            logger.debug("Memory service not available, skipping memory storage")
+            return False
+        user_id = await get_user_id_from_thread(db, thread_id)
+        if not user_id:
+            logger.warning(
+                f"Could not get user_id for thread {thread_id}, skipping memory storage"
+            )
+            return False
+        if conversation_messages is None:
+            conversation_messages = await get_recent_conversation_messages(
+                db, thread_id, limit=10
+            )
+        if not conversation_messages:
+            logger.debug(f"No conversation messages found for thread {thread_id}")
+            return False
+        memory_hash = _compute_memory_hash(conversation_messages)
+        memory_metadata: Dict[str, Any] = {
+            "type": "conversation",
+            "message_count": len(conversation_messages),
+            "stored_at": "conversation_end",
+            "memory_hash": memory_hash,
+        }
+        if agent_run_id:
+            memory_metadata["agent_run_id"] = agent_run_id
+        if additional_context:
+            memory_metadata["additional_context"] = additional_context
+        # Store as user-level (thread_id=None) so the memory is found in new chats
+        success = await memory_service.add_memory(
+            content=conversation_messages,
+            user_id=user_id,
+            thread_id=None,
+            metadata=memory_metadata,
+        )
+        if success:
+            logger.info(
+                f"Successfully stored conversation memory for thread {thread_id} (user: {user_id})"
+            )
+        else:
+            logger.warning(f"Failed to store conversation memory for thread {thread_id}")
+        return success
+    except Exception as e:
+        logger.error(
+            f"Error storing conversation memory for thread {thread_id}: {e}",
+            exc_info=True,
+        )
+        return False
+
+
+async def retrieve_relevant_memories(
+    db: DBConnection,
+    thread_id: str,
+    query: str,
+    limit: int = 5,
+) -> Optional[str]:
+    """
+    Retrieve relevant memories before sending message to agent.
+
+    Uses Redis caching to avoid repeated identical searches.
+
+    Args:
+        db: Database connection
+        thread_id: Thread identifier
+        query: User's current message/query
+        limit: Maximum number of memories to retrieve
+
+    Returns:
+        Formatted memory context string or None if no memories found
+    """
+    try:
+        if not memory_service.is_available():
+            logger.debug("Memory service not available, skipping memory retrieval")
+            return None
+        user_id = await get_user_id_from_thread(db, thread_id)
+        if not user_id:
+            logger.warning(
+                f"Could not get user_id for thread {thread_id}, skipping memory retrieval"
+            )
+            return None
+        logger.info(
+            f"Memory retrieval: looking up memories for user (thread {thread_id})",
+            extra={"user_id": user_id, "thread_id": thread_id, "query_preview": query[:80]},
+        )
+        cache_ttl = getattr(config, "SUPERMEMORY_CACHE_TTL", 45)
+        cache_key = _generate_memory_cache_key(user_id, thread_id, query, limit)
+        try:
+            cached_result = await redis.get(cache_key)
+            if cached_result:
+                logger.debug(f"Memory cache hit for key: {cache_key}")
+                decoded = cached_result if isinstance(cached_result, str) else (cached_result.decode("utf-8") if isinstance(cached_result, bytes) else str(cached_result))
+                if decoded:
+                    return decoded
+        except Exception:
+            pass
+        relevant_memories = await memory_service.search_memories(
+            query=query,
+            user_id=user_id,
+            thread_id=None,  # Search user-level memories so agent remembers across threads/chats
+            limit=limit,
+        )
+        # Fallback: if no results, try broader search so "do you remember my team?" still finds context
+        if not relevant_memories and query:
+            fallback_query = "user information work team preferences context"
+            logger.info(f"Memory retrieval: trying fallback query {fallback_query!r}")
+            relevant_memories = await memory_service.search_memories(
+                query=fallback_query,
+                user_id=user_id,
+                thread_id=None,
+                limit=limit,
+            )
+        if not relevant_memories:
+            logger.info(
+                f"No relevant memories found for user (cross-thread)",
+                extra={"user_id": user_id, "thread_id": thread_id, "query_preview": query[:80]},
+            )
+            try:
+                await redis.set(cache_key, "", ex=cache_ttl)
+            except Exception:
+                pass
+            return None
+        memory_context_parts = [MEMORY_CONTEXT_HEADER]
+        for i, memory in enumerate(relevant_memories):
+            memory_text = memory.get("memory", memory.get("text", ""))
+            if isinstance(memory_text, dict):
+                memory_text = memory_text.get("text") or memory_text.get("content") or memory_text.get("chunk") or str(memory_text)
+            memory_text = (memory_text or "").strip()
+            if memory_text:
+                memory_context_parts.append(f"{i + 1}. {memory_text}")
+        if len(memory_context_parts) == 1:
+            # Header but no memory items - extraction may be using wrong field names
+            logger.warning(
+                "Memory retrieval: 0 memories had non-empty text; first result keys: %s",
+                list(relevant_memories[0].keys()) if relevant_memories else [],
+                extra={"user_id": user_id, "thread_id": thread_id},
+            )
+        memory_context_parts.append(MEMORY_CONTEXT_FOOTER)
+        memory_context = "\n".join(memory_context_parts)
+        try:
+            await redis.set(cache_key, memory_context, ex=cache_ttl)
+        except Exception:
+            pass
+        logger.debug(
+            f"Retrieved {len(relevant_memories)} relevant memories for user {user_id}",
+            extra={"user_id": user_id, "thread_id": thread_id, "memories_count": len(relevant_memories)},
+        )
+        logger.info(
+            f"Memory retrieval: found {len(relevant_memories)} relevant memories for user (cross-thread)",
+            extra={"user_id": user_id, "thread_id": thread_id},
+        )
+        return memory_context
+    except Exception as e:
+        logger.error(f"Error retrieving relevant memories: {e}", exc_info=True)
+        return None
+
+
+store_memory_on_completion = store_conversation_memory

--- a/backend/core/utils/config.py
+++ b/backend/core/utils/config.py
@@ -383,7 +383,14 @@ class Configuration:
     FIRECRAWL_URL: Optional[str] = "https://api.firecrawl.dev"
     EXA_API_KEY: Optional[str] = None
     SEMANTIC_SCHOLAR_API_KEY: Optional[str] = None
-    
+
+    # Memory service (Supermemory) configuration
+    SUPERMEMORY_API_KEY: Optional[str] = None
+    SUPERMEMORY_REQUEST_TIMEOUT: float = 20.0
+    SUPERMEMORY_MAX_RETRIES: int = 4
+    SUPERMEMORY_RETRY_DELAY: float = 1.0
+    SUPERMEMORY_CACHE_TTL: int = 45  # Redis cache TTL in seconds for memory retrievals
+
     VAPI_PRIVATE_KEY: Optional[str] = None
     VAPI_PHONE_NUMBER_ID: Optional[str] = None
     VAPI_SERVER_URL: Optional[str] = None
@@ -605,6 +612,12 @@ class Configuration:
                     # Handle integer conversion
                     try:
                         setattr(self, key, int(env_val))
+                    except ValueError:
+                        logger.warning(f"Invalid value for {key}: {env_val}, using default")
+                elif expected_type == float:
+                    # Handle float conversion
+                    try:
+                        setattr(self, key, float(env_val))
                     except ValueError:
                         logger.warning(f"Invalid value for {key}: {env_val}, using default")
                 else:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
   "cssutils>=2.9.0",
   "fastapi-sso>=0.9.0",
   "daytona>=0.21.6",
+  "supermemory>=3.26.0",
   "google-api-python-client>=2.120.0",
   "google-auth>=2.28.0",
   "google-auth-oauthlib>=1.2.0",

--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -16,6 +16,7 @@ from typing import Optional, Dict, Any, Tuple
 from core.services import redis_worker as redis
 from core.run import run_agent
 from core.utils.logger import logger, structlog
+from core.services.memory_integration import store_conversation_memory
 from core.utils.tool_discovery import warm_up_tools_cache
 import dramatiq
 import uuid
@@ -96,6 +97,13 @@ async def initialize():
     logger.info(f"Initializing worker async resources with Redis at {redis_host}:{redis_port}")
     await retry(lambda: redis.initialize_async())
     await db.initialize()
+
+    # Initialize main Redis so memory_integration cache works in worker
+    try:
+        from core.services import redis as main_redis
+        await main_redis.initialize_async()
+    except Exception as redis_err:
+        logger.warning(f"Failed to initialize main Redis in worker (memory cache may be skipped): {redis_err}")
     
     from core.utils.tool_discovery import warm_up_tools_cache
     warm_up_tools_cache()
@@ -113,6 +121,42 @@ async def initialize():
 async def check_health(key: str):
     structlog.contextvars.clear_contextvars()
     await redis.set(key, "healthy", ex=redis.REDIS_KEY_TTL)
+
+
+@dramatiq.actor
+async def store_conversation_memory_background(
+    thread_id: str,
+    additional_context: Optional[str] = None,
+    agent_run_id: Optional[str] = None,
+):
+    """
+    Store conversation memory in the background using Dramatiq.
+
+    This actor handles memory storage asynchronously to avoid blocking
+    the main agent run completion process.
+    """
+    structlog.contextvars.clear_contextvars()
+    structlog.contextvars.bind_contextvars(
+        thread_id=thread_id,
+        agent_run_id=agent_run_id,
+    )
+    try:
+        await initialize()
+        success = await store_conversation_memory(
+            db=db,
+            thread_id=thread_id,
+            additional_context=additional_context,
+            agent_run_id=agent_run_id,
+        )
+        if success:
+            logger.info(f"Successfully stored conversation memory for thread {thread_id}")
+        else:
+            logger.warning(f"Failed to store conversation memory for thread {thread_id}")
+    except Exception as e:
+        logger.error(
+            f"Error in background memory storage for thread {thread_id}: {str(e)}",
+            exc_info=True,
+        )
 
 
 async def acquire_run_lock(agent_run_id: str, instance_id: str, client) -> bool:
@@ -601,6 +645,18 @@ async def run_agent_background(
             if not complete_tool_called:
                 logger.info(f"Agent run {agent_run_id} completed without explicit complete tool call - skipping notification")
 
+            # Store conversation memory asynchronously on successful completion
+            try:
+                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+                store_conversation_memory_background.send(
+                    thread_id=thread_id,
+                    additional_context=f"Agent run {agent_run_id} completed successfully after {duration:.2f}s with {total_responses} responses",
+                    agent_run_id=agent_run_id,
+                )
+                logger.info(f"Enqueued conversation memory storage for thread {thread_id} (run {agent_run_id})")
+            except Exception as mem_err:
+                logger.warning(f"Failed to dispatch conversation memory storage on completion: {mem_err}")
+
         all_responses_json = await redis.lrange(redis_keys['response_list'], 0, -1)
         all_responses = [json.loads(r) for r in all_responses_json]
 
@@ -608,6 +664,19 @@ async def run_agent_background(
 
         if final_status == "failed" and error_message:
             await send_failure_notification(client, thread_id, error_message)
+
+        # Store conversation memory for failed/stopped runs if there was meaningful conversation
+        if final_status in ["failed", "stopped"] and total_responses > 0:
+            try:
+                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+                store_conversation_memory_background.send(
+                    thread_id=thread_id,
+                    additional_context=f"Agent run {agent_run_id} {final_status} after {duration:.2f}s with {total_responses} responses. Error: {error_message or 'None'}",
+                    agent_run_id=agent_run_id,
+                )
+                logger.info(f"Enqueued conversation memory storage for {final_status} run thread {thread_id} (run {agent_run_id})")
+            except Exception as mem_err:
+                logger.warning(f"Failed to dispatch conversation memory storage for {final_status} run: {mem_err}")
 
         stop_reason = stop_signal_checker_state.get('stop_reason')
         await publish_final_control_signal(final_status, redis_keys['global_control_channel'], stop_reason=stop_reason)
@@ -630,6 +699,19 @@ async def run_agent_background(
             logger.error(f"Failed to push error response to Redis for {agent_run_id}: {redis_err}")
 
         await update_agent_run_status(client, agent_run_id, "failed", error=f"{error_message}\n{traceback_str}", account_id=account_id)
+
+        # Store conversation memory if there was meaningful conversation before the error
+        try:
+            response_list = await redis.lrange(redis_keys["response_list"], 0, -1)
+            if len(response_list) > 0:
+                store_conversation_memory_background.send(
+                    thread_id=thread_id,
+                    additional_context=f"Agent run {agent_run_id} failed with exception after {duration:.2f}s with {len(response_list)} responses. Error: {error_message}",
+                    agent_run_id=agent_run_id,
+                )
+                logger.info(f"Enqueued conversation memory storage for failed run thread {thread_id} (run {agent_run_id})")
+        except Exception as mem_err:
+            logger.warning(f"Failed to dispatch conversation memory storage for failed run: {mem_err}")
 
         try:
             await redis.publish(redis_keys['global_control_channel'], "ERROR")


### PR DESCRIPTION
## Summary
Migrates the memory layer from mem0 to Supermemory.

## Changes
- **New:** Supermemory service and integration
  - `backend/core/services/memory.py` – Supermemory client/service
  - `backend/core/services/memory_api.py` – API layer for memory
  - `backend/core/services/memory_integration.py` – Integration with agent/thread flow
- **Updated:** Call sites and config
  - `backend/api.py` – Memory endpoints / wiring
  - `backend/core/agentpress/thread_manager.py` – Thread–memory integration
  - `backend/core/utils/config.py` – Supermemory URL/config
  - `backend/pyproject.toml` – Dependencies (mem0 removed, supermemory added)
  - `backend/run_agent_background.py` – Memory usage in background agent