### PR TITLE
Improve custom worker creation chat flow

### DIFF
--- a/backend/core/agent_runs.py
+++ b/backend/core/agent_runs.py
@@ -375,6 +375,7 @@ async def _trigger_agent_background(
     account_id: Optional[str] = None,
     enable_thinking: bool = False,
     reasoning_effort: str = "low",
+    create_worker_chat: bool = False,
 ):
     """
     Trigger the background agent execution.
@@ -388,10 +389,11 @@ async def _trigger_agent_background(
         account_id: Account ID for authorization in worker
         enable_thinking: Enable extended thinking/reasoning
         reasoning_effort: Reasoning effort level (low/medium/high)
+        create_worker_chat: If True, prepend agent-creator session prompt for "Start a chat to customise worker"
     """
     request_id = structlog.contextvars.get_contextvars().get('request_id')
 
-    logger.info(f"🚀 Sending agent run {agent_run_id} to Dramatiq queue (thread: {thread_id}, model: {effective_model}, thinking: {enable_thinking})")
+    logger.info(f"🚀 Sending agent run {agent_run_id} to Dramatiq queue (thread: {thread_id}, model: {effective_model}, thinking: {enable_thinking}, create_worker_chat: {create_worker_chat})")
     
     try:
         message = run_agent_background.send(
@@ -405,6 +407,7 @@ async def _trigger_agent_background(
             request_id=request_id,
             enable_thinking=enable_thinking,
             reasoning_effort=reasoning_effort,
+            create_worker_chat=create_worker_chat,
         )
         message_id = message.message_id if hasattr(message, 'message_id') else 'N/A'
         logger.info(f"✅ Successfully enqueued agent run {agent_run_id} to Dramatiq (message_id: {message_id})")
@@ -624,6 +627,7 @@ async def start_agent_run(
     skip_limits_check: bool = False,  # For triggers that have their own limits
     enable_thinking: bool = False,
     reasoning_effort: str = "low",
+    create_worker_chat: bool = False,
 ) -> Dict[str, Any]:
     """
     Core function to start an agent run.
@@ -786,7 +790,7 @@ async def start_agent_run(
     
     # Trigger background execution
     t_dispatch = time.time()
-    await _trigger_agent_background(agent_run_id, thread_id, project_id, effective_model, agent_id, account_id, enable_thinking, reasoning_effort)
+    await _trigger_agent_background(agent_run_id, thread_id, project_id, effective_model, agent_id, account_id, enable_thinking, reasoning_effort, create_worker_chat)
     logger.debug(f"⏱️ [TIMING] Worker dispatch: {(time.time() - t_dispatch) * 1000:.1f}ms")
     
     logger.info(f"⏱️ [TIMING] start_agent_run total: {(time.time() - t_start) * 1000:.1f}ms")
@@ -812,6 +816,7 @@ async def unified_agent_start(
     agent_id: Optional[str] = Form(None),
     enable_thinking: Optional[bool] = Form(False),
     reasoning_effort: Optional[str] = Form("low"),
+    create_worker_chat: Optional[bool] = Form(False),
     files: List[UploadFile] = File(default=[]),
     user_id: str = Depends(verify_and_get_user_id_from_jwt)
 ):
@@ -933,11 +938,17 @@ async def unified_agent_start(
             message_content=message_content,  # Includes file references if any
             enable_thinking=enable_thinking,
             reasoning_effort=reasoning_effort,
+            create_worker_chat=bool(create_worker_chat),
         )
         
         logger.info(f"⏱️ [TIMING] 🎯 API Request Total: {(time.time() - api_request_start) * 1000:.1f}ms")
         
-        return {"thread_id": result["thread_id"], "agent_run_id": result["agent_run_id"], "status": "running"}
+        return {
+            "thread_id": result["thread_id"],
+            "agent_run_id": result["agent_run_id"],
+            "project_id": result.get("project_id"),
+            "status": "running",
+        }
     
     except HTTPException:
         raise

--- a/backend/core/api_models/threads.py
+++ b/backend/core/api_models/threads.py
@@ -8,6 +8,7 @@ class UnifiedAgentStartResponse(BaseModel):
     """Unified response model for agent start (both new and existing threads)."""
     thread_id: str
     agent_run_id: str
+    project_id: Optional[str] = None  # Present for new threads; used for redirect
     status: str = "running"
 
 

--- a/backend/core/prompts/agent_builder_prompt.py
+++ b/backend/core/prompts/agent_builder_prompt.py
@@ -379,5 +379,34 @@ When users ask about:
 **Remember**: You maintain your core personality and expertise while offering these additional configuration and building capabilities. Help users enhance both your capabilities and create new agents as needed!"""
 
 
+# Dedicated prompt when this chat is started via "Start a chat to customise worker".
+# Prepended to system prompt so the AI asks clarifying questions then uses create_new_agent/update_agent_config.
+# Style follows message_tool ask: numbered questions, friendly tone.
+AGENT_CREATOR_SESSION_PROMPT = """
+=== THIS CHAT IS FOR CREATING ONE CUSTOM WORKER ===
+
+You are in an agent-creation session. The user's FIRST message in this conversation is their initial idea for a custom worker. Your ONLY goal in this chat is to:
+
+1. **Ask clarifying questions** using the `ask` tool so you can formalize how the worker should behave. Use natural, conversational language. Example questions you should ask (adapt to their description):
+   - What should we name this worker?
+   - What specific tasks should it perform? (e.g. research, writing, data analysis, support)
+   - What tone or style should it use? (e.g. professional, friendly, technical)
+   - Should it have access to web search, files, or external integrations (Gmail, Slack, etc.)?
+   - What would success look like for this worker? Any constraints or preferences?
+   - Who is the primary audience or use case?
+
+2. **After you have enough detail**, summarize the worker spec and use the `ask` tool to confirm with the user (e.g. "Here's what I'll create: ... Should I go ahead?").
+
+3. **Once the user confirms**, use `create_new_agent` with the name, description, system_prompt, icon_name, icon_color, icon_background (and optional agentpress_tools, configured_mcps). If the user wants changes after creation, use `update_agent_config`.
+
+Stay focused on creating this one worker. Do not switch to other tasks. The user's initial description is in their first message—use it as the starting point, then refine with your questions.
+=== END AGENT-CREATOR SESSION ===
+"""
+
+
 def get_agent_builder_prompt():
     return AGENT_BUILDER_SYSTEM_PROMPT
+
+
+def get_agent_creator_session_prompt():
+    return AGENT_CREATOR_SESSION_PROMPT

--- a/backend/core/run.py
+++ b/backend/core/run.py
@@ -10,7 +10,7 @@ from core.tools.web_search_tool import SandboxWebSearchTool
 from core.tools.image_search_tool import SandboxImageSearchTool
 from dotenv import load_dotenv
 from core.utils.config import config, EnvMode
-from core.prompts.agent_builder_prompt import get_agent_builder_prompt
+from core.prompts.agent_builder_prompt import get_agent_builder_prompt, get_agent_creator_session_prompt
 from core.agentpress.thread_manager import ThreadManager
 from core.agentpress.response_processor import ProcessorConfig
 from core.agentpress.error_processor import ErrorProcessor
@@ -49,6 +49,7 @@ class AgentConfig:
     account_id: Optional[str] = None  # If provided, skip thread query in setup()
     enable_thinking: bool = False
     reasoning_effort: str = "low"
+    create_worker_chat: bool = False  # When True, prepend agent-creator session prompt
 
 class ToolManager:
     def __init__(self, thread_manager: ThreadManager, project_id: str, thread_id: str, agent_config: Optional[dict] = None):
@@ -351,7 +352,8 @@ class PromptManager:
                                   client=None,
                                   tool_registry=None,
                                   xml_tool_calling: bool = False,
-                                  user_id: Optional[str] = None) -> dict:
+                                  user_id: Optional[str] = None,
+                                  create_worker_chat: bool = False) -> dict:
         
         default_system_content = get_system_prompt()
         
@@ -366,6 +368,10 @@ class PromptManager:
             system_content = agent_config['system_prompt'].strip()
         else:
             system_content = default_system_content
+        
+        # When this chat is for creating one custom worker, prepend the agent-creator session prompt
+        if create_worker_chat:
+            system_content = get_agent_creator_session_prompt().strip() + "\n\n" + system_content
         
         # Check if agent has builder tools enabled - append the full builder prompt
         if agent_config:
@@ -921,7 +927,8 @@ class AgentRunner:
             mcp_wrapper_instance, self.client,
             tool_registry=self.thread_manager.tool_registry,
             xml_tool_calling=config.AGENT_XML_TOOL_CALLING,
-            user_id=self.account_id
+            user_id=self.account_id,
+            create_worker_chat=self.config.create_worker_chat,
         )
         logger.info(f"⏱️ [TIMING] build_system_prompt() in {(time.time() - prompt_start) * 1000:.1f}ms ({len(str(system_message.get('content', '')))} chars)")
         logger.debug(f"model_name received: {self.config.model_name}")
@@ -1148,6 +1155,7 @@ async def run_agent(
     account_id: Optional[str] = None,  # If provided, skips thread query in setup()
     enable_thinking: bool = False,
     reasoning_effort: str = "low",
+    create_worker_chat: bool = False,
 ):
     effective_model = model_name
     
@@ -1162,6 +1170,7 @@ async def run_agent(
         account_id=account_id,
         enable_thinking=enable_thinking,
         reasoning_effort=reasoning_effort,
+        create_worker_chat=create_worker_chat,
     )
     
     runner = AgentRunner(config)

--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -456,6 +456,7 @@ async def run_agent_background(
     request_id: Optional[str] = None,
     enable_thinking: bool = False,
     reasoning_effort: str = "low",
+    create_worker_chat: bool = False,
 ):
     worker_start = time.time()
     timings = {}
@@ -583,6 +584,7 @@ async def run_agent_background(
             account_id=account_id,
             enable_thinking=enable_thinking,
             reasoning_effort=reasoning_effort,
+            create_worker_chat=create_worker_chat,
         )
         
         total_to_ready = (time.time() - worker_start) * 1000

--- a/frontend/src/components/agents/agent-creation-modal.tsx
+++ b/frontend/src/components/agents/agent-creation-modal.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useCreateNewAgent } from '@/hooks/agents/use-agents';
+import { useInitiateAgentWithInvalidation } from '@/hooks/dashboard/use-initiate-agent';
 import { useKortixTeamTemplates } from '@/hooks/secure-mcp/use-secure-mcp';
 import { AgentCountLimitError } from '@/lib/api/errors';
 import { toast } from 'sonner';
@@ -56,8 +57,10 @@ export function AgentCreationModal({ open, onOpenChange, onSuccess }: AgentCreat
   const [chatDescription, setChatDescription] = useState('');
 
   const createNewAgentMutation = useCreateNewAgent();
+  const initiateAgentMutation = useInitiateAgentWithInvalidation();
   // Only fetch templates when modal is open to avoid unnecessary API calls
   const { data: templates } = useKortixTeamTemplates({ enabled: open });
+  const isCreating = createNewAgentMutation.isPending || initiateAgentMutation.isPending;
 
   const handleExploreTemplates = () => {
     onOpenChange(false);
@@ -142,7 +145,7 @@ export function AgentCreationModal({ open, onOpenChange, onSuccess }: AgentCreat
     }
   };
 
-  const handleChatContinue = async () => {
+  const handleCreateWorker = async () => {
     if (!chatDescription.trim()) {
       toast.error('Please describe what your Worker should be able to do');
       return;
@@ -167,6 +170,31 @@ export function AgentCreationModal({ open, onOpenChange, onSuccess }: AgentCreat
         onOpenChange(false);
       } else {
         console.error('Error creating agent from chat:', error);
+      }
+    }
+  };
+
+  const handleStartChatToCreateWorker = async () => {
+    if (!chatDescription.trim()) {
+      toast.error('Please describe what your Worker should be able to do');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('prompt', chatDescription.trim());
+    formData.append('create_worker_chat', 'true');
+
+    try {
+      const data = await initiateAgentMutation.mutateAsync(formData);
+      if (data.project_id) {
+        router.push(`/projects/${data.project_id}/thread/${data.thread_id}`);
+      } else {
+        router.push(`/agents/${data.thread_id}`);
+      }
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof AgentCountLimitError) {
+        onOpenChange(false);
       }
     }
   };
@@ -298,17 +326,28 @@ export function AgentCreationModal({ open, onOpenChange, onSuccess }: AgentCreat
 
               {/* Actions */}
               <div className="flex flex-col gap-2 sm:gap-3">
-                <Button
-                  onClick={handleChatContinue}
-                  disabled={!chatDescription.trim() || createNewAgentMutation.isPending}
-                  className="w-full h-9 sm:h-10 text-sm"
-                >
-                  {createNewAgentMutation.isPending ? 'Creating...' : 'Create Worker'}
-                </Button>
+                <div className="flex flex-col sm:flex-row gap-2 sm:gap-3">
+                  <Button
+                    variant="outline"
+                    onClick={handleCreateWorker}
+                    disabled={!chatDescription.trim() || isCreating}
+                    className="w-full sm:flex-1 h-9 sm:h-10 text-sm bg-white text-foreground hover:bg-white/90 dark:bg-white dark:text-black"
+                  >
+                    {createNewAgentMutation.isPending ? 'Creating...' : 'Create worker'}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={handleStartChatToCreateWorker}
+                    disabled={!chatDescription.trim() || isCreating}
+                    className="w-full sm:flex-1 h-9 sm:h-10 text-sm bg-white text-foreground hover:bg-white/90 dark:bg-white dark:text-black"
+                  >
+                    {initiateAgentMutation.isPending ? 'Starting chat...' : 'Start a chat to customise worker'}
+                  </Button>
+                </div>
                 <Button 
                   variant="ghost" 
                   onClick={handleBack} 
-                  disabled={createNewAgentMutation.isPending}
+                  disabled={isCreating}
                   className="w-full h-9 sm:h-10 text-sm text-muted-foreground"
                 >
                   <ChevronLeft className="w-4 h-4 mr-1" />

--- a/frontend/src/hooks/dashboard/use-initiate-agent.ts
+++ b/frontend/src/hooks/dashboard/use-initiate-agent.ts
@@ -38,6 +38,7 @@ export const useInitiateAgentMutation = () => {
       const model_name = model_name_raw && model_name_raw.trim() ? model_name_raw.trim() : undefined;
       const agent_id = formData.get('agent_id') as string | undefined;
       const files = formData.getAll('files') as File[];
+      const create_worker_chat = formData.get('create_worker_chat') === 'true';
       
       // Debug logging
       console.log('[useInitiateAgent] Extracted from FormData:', {
@@ -47,6 +48,7 @@ export const useInitiateAgentMutation = () => {
         model_name,
         agent_id,
         filesCount: files.length,
+        create_worker_chat,
       });
       
       return await unifiedAgentStart({
@@ -54,6 +56,7 @@ export const useInitiateAgentMutation = () => {
         model_name,
         agent_id,
         files: files.length > 0 ? files : undefined,
+        create_worker_chat: create_worker_chat || undefined,
       });
     },
     onSuccess: (data) => {

--- a/frontend/src/lib/api/agents.ts
+++ b/frontend/src/lib/api/agents.ts
@@ -25,6 +25,7 @@ export type ToolCall = {
 export interface UnifiedAgentStartResponse {
   thread_id: string;
   agent_run_id: string;
+  project_id?: string | null;
   status: string;
 }
 
@@ -65,6 +66,7 @@ export const unifiedAgentStart = async (options: {
   files?: File[];
   model_name?: string;
   agent_id?: string;
+  create_worker_chat?: boolean;
 }): Promise<{ thread_id: string; agent_run_id: string; status: string }> => {
   try {
     if (!API_URL) {
@@ -92,6 +94,10 @@ export const unifiedAgentStart = async (options: {
     
     if (options.agent_id) {
       formData.append('agent_id', options.agent_id);
+    }
+    
+    if (options.create_worker_chat) {
+      formData.append('create_worker_chat', 'true');
     }
     
     if (options.files && options.files.length > 0) {


### PR DESCRIPTION
## Summary

Improve the custom worker creation flow so users can either one-click create a worker from a description or start an interactive chat that guides worker creation.

## Changes
### Backend

- Thread start `(/agent/start)` now supports a `create_worker_chat` flag flowing from `agent_runs` → `background worker` → `run_agent`.

- When `create_worker_chat` is true, the system prompt is prefixed with an agent-creator session prompt that guides the model to ask clarifying questions and then call `create_new_agent` / `update_agent_config`.

- Unified start response now includes `project_id` to support direct redirects to the new chat.

### Frontend

Updated the “Describe your Worker” step in the agent creation modal:

- Added two primary actions: Create worker (one-shot agent setup) and Start a chat to create a worker (initiates a normal chat run with create_worker_chat=true).

- Implemented auto-redirect to the new chat thread after starting the worker-creation chat.